### PR TITLE
Added some very basic tests for YamlHeader() extension method.

### DIFF
--- a/src/Pretzel.Tests/Pretzel.Tests.csproj
+++ b/src/Pretzel.Tests/Pretzel.Tests.csproj
@@ -48,9 +48,16 @@
     <Compile Include="PretzelContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SampleTest.cs" />
+    <Compile Include="YamlExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Pretzel.Logic\Pretzel.Logic.csproj">
+      <Project>{F2E6664D-75AC-4830-8A55-E572027DF710}</Project>
+      <Name>Pretzel.Logic</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/src/Pretzel.Tests/YamlExtensionsTests.cs
+++ b/src/Pretzel.Tests/YamlExtensionsTests.cs
@@ -1,0 +1,37 @@
+﻿using Pretzel.Logic.Extensions;
+using Xunit;
+
+namespace Pretzel.Tests
+{
+    public class YamlExtensionsTests
+    {
+        public class YamlHeaderTests
+        {
+            [Fact]
+            public void Parse_multiple_fields_in_header()
+            {
+                const string header = @"---
+                        layout: post
+                        title: This is a test jekyll document
+                        description: TEST ALL THE THINGS
+                        date: 2012-01-30
+                        tags : 
+                        - test
+                        - alsotest
+                        - lasttest
+                        ---
+            
+                        ##Test
+            
+                        This is a test of YAML parsing";
+
+                var result = header.YamlHeader();
+
+                Assert.Equal("post", result["layout"].ToString());
+                Assert.Equal("This is a test jekyll document", result["title"].ToString());
+                Assert.Equal("2012-01-30", result["date"].ToString());
+                Assert.Equal("[ test, alsotest, lasttest ]", result["tags"].ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simple test using .ToString() on YamlNode. This avoids a test proj dependency on YamlNode, but could also prove a brittle test.
Feel free to leave it unmerged.
