### PR TITLE
Tracing.Info("Templating Engine not found");

### DIFF
--- a/src/Pretzel.Logic/Recipe/Recipe.cs
+++ b/src/Pretzel.Logic/Recipe/Recipe.cs
@@ -44,8 +44,7 @@ namespace Pretzel.Logic
 
                     Tracing.Info("Pretzel site template has been created");
                 }
-
-                if (string.Equals("liquid", engine, StringComparison.InvariantCultureIgnoreCase))
+                else if (string.Equals("liquid", engine, StringComparison.InvariantCultureIgnoreCase))
                 {
                     CreateDirectories();
 


### PR DESCRIPTION
Small fix so that Tracing.Info("Templating Engine not found"); is not called even after successfully creating a site.
