### PR TITLE
Fix yaml headers in wordpress import

### DIFF
--- a/src/Pretzel.Logic/Import/WordpressImport.cs
+++ b/src/Pretzel.Logic/Import/WordpressImport.cs
@@ -56,10 +56,11 @@ namespace Pretzel.Logic.Import
         {
             var header = new
             {
-                Title = p.Title,
-                Layout = "post",
-                Categories = p.Categories,
-                Tags = p.Tags
+                title = p.Title,
+                date = p.Published,
+                layout = "post",
+                categories = p.Categories,
+                tags = p.Tags
             };
 
             var yamlHeader = string.Format("---\r\n{0}---\r\n\r\n", header.ToYaml());

--- a/src/Pretzel.Tests/Import/WordpressImportTests.cs
+++ b/src/Pretzel.Tests/Import/WordpressImportTests.cs
@@ -112,7 +112,7 @@ namespace Pretzel.Tests.Import
             var postContent = fileSystem.File.ReadAllText(BaseSite + "_posts\\2010-02-06-hello-world.md");
             var header = postContent.YamlHeader();
 
-            Assert.Equal("Hello world!", header["Title"].ToString());
+            Assert.Equal("Hello world!", header["title"].ToString());
         }
     }
 }


### PR DESCRIPTION
jekyll engine didnt like the upper case
