### PR TITLE
Avoids having a null pointer exception when typing an invalid command name

### DIFF
--- a/src/Pretzel/Commands/CommandCollection.cs
+++ b/src/Pretzel/Commands/CommandCollection.cs
@@ -43,5 +43,12 @@ namespace Pretzel.Commands
                 command.Value.WriteHelp(Console.Out);
             }
         }
+
+        public void WriteInvalidCommand(string commandName)
+        {
+            Console.Error.WriteLine("'{0}' is not a valid command", commandName);
+            Console.WriteLine();
+            WriteHelp();
+        }
     }
 }

--- a/src/Pretzel/Program.cs
+++ b/src/Pretzel/Program.cs
@@ -31,7 +31,13 @@ namespace Pretzel
 
             var commandName = args[0];
             var commandArgs = args.Skip(1).ToArray();
-            Commands[commandName].Execute(commandArgs);
+            var command = Commands[commandName];
+            if (command == null)
+            {
+                Commands.WriteInvalidCommand(commandName);
+                return;
+            }
+            command.Execute(commandArgs);
             WaitForClose();
         }
 


### PR DESCRIPTION
While trying the commands I made a typo in the bake command name and had a null pointer exception.
This displays a small error message.
