### PR TITLE
We've already skipped the commandName - no reason to do it again, fixes ...

### DIFF
--- a/src/Pretzel/Program.cs
+++ b/src/Pretzel/Program.cs
@@ -64,7 +64,7 @@ namespace Pretzel
                 return;
             }
 
-            Commands[commandName].Execute(commandArgs.Skip(1));
+            Commands[commandName].Execute(commandArgs);
             WaitForClose();
         }
 


### PR DESCRIPTION
the parameters to prevent removing the first one after we've removed teh command name
