### PR TITLE
Relative path Support

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -23,6 +23,9 @@ namespace Pretzel.Logic.Templating.Context
 
         public SiteContext BuildContext(string path)
         {
+            if (!Path.IsPathRooted(path))
+                path = Path.Combine(Environment.CurrentDirectory, path);
+
             var config = new Dictionary<string, object>();
             if (File.Exists(Path.Combine(path, "_config.yml")))
                 config = (Dictionary<string, object>)File.ReadAllText(Path.Combine(path, "_config.yml")).YamlHeader(true);


### PR DESCRIPTION
This allows you to do:

c:\sites>Pretzel create NewSite

c:\sites Pretzel taste NewSite

Before this would result in broken links, now the generated site works fine
