### PR TITLE
Inline YAML-like content crashed the parser

### DIFF
--- a/src/Pretzel.Logic/Extensions/YamlExtensions.cs
+++ b/src/Pretzel.Logic/Extensions/YamlExtensions.cs
@@ -8,7 +8,7 @@ namespace Pretzel.Logic.Extensions
 {
     public static class YamlExtensions
     {
-        static readonly Regex r = new Regex(@"^---([\d\D\w\W\s\S]+)---", RegexOptions.Multiline);
+        static readonly Regex r = new Regex(@"(?s:^---(.*?)---)");
         public static IDictionary<string, object> YamlHeader(this string text, bool skipHeader = false)
         {
             StringReader input;

--- a/src/Pretzel.Tests/YamlExtensionsTests.cs
+++ b/src/Pretzel.Tests/YamlExtensionsTests.cs
@@ -69,6 +69,49 @@ namespace Pretzel.Tests
             {
                 Assert.NotNull("".YamlHeader());
             }
+
+            [Fact]
+            public void YamlHeader_WithInlineDataThatLooksLikeAnotherHeader_IgnoresTheInlineData()
+            {
+                const string header = @"---
+layout: post
+title: This is a test jekyll document
+description: TEST ALL THE THINGS
+date: 2012-01-30
+tags : 
+- test
+- alsotest
+- lasttest
+---
+
+##Test
+
+This is a test of YAML parsing
+
+    ---
+    layout: inline-post
+    title: inline-title
+    description: inline description
+    date: 2010-04-09
+    tags : 
+    - foo
+    - bar
+    - baz
+    ---";
+
+                var result = header.YamlHeader();
+
+                Assert.Equal("post", result["layout"].ToString());
+                Assert.Equal("This is a test jekyll document", result["title"].ToString());
+                Assert.Equal("2012-01-30", result["date"].ToString());
+                Assert.Equal("TEST ALL THE THINGS", result["description"].ToString());
+
+                var tags = result["tags"] as IList<string>;
+                Assert.Equal(3, tags.Count);
+                Assert.Equal("test", tags[0]);
+                Assert.Equal("alsotest", tags[1]);
+                Assert.Equal("lasttest", tags[2]);
+            }
         }
     }
 }


### PR DESCRIPTION
If you have something that looks like YAML Front Matter later in your markdown file, it reads both the original header, and the latter one, and all the content in between, as a single block of YAML. This fixes it.
