### PR TITLE
Test and fix for multiple sequence diagrams being swallowed into one

### DIFF
--- a/src/Pretzel.Logic/Extensibility/Extensions/WebSequenceDiagrams.cs
+++ b/src/Pretzel.Logic/Extensibility/Extensions/WebSequenceDiagrams.cs
@@ -6,7 +6,7 @@ namespace Pretzel.Logic.Extensibility.Extensions
     [Export(typeof(IContentTransform))]
     public class WebSequenceDiagrams : IContentTransform
     {
-        static readonly Regex SequenceDiagramRegex = new Regex(@"(?s:<pre><code>@@sequence(?<style>.*?)\r?\n(?<sequenceContent>.*)</code></pre>)");
+        static readonly Regex SequenceDiagramRegex = new Regex(@"(?s:<pre><code>@@sequence(?<style>.*?)\r?\n(?<sequenceContent>.*?)</code></pre>)");
 
         public string Transform(string content)
         {

--- a/src/Pretzel.Tests/Extensibility/Extensions/WebSequenceDiagramsTests.cs
+++ b/src/Pretzel.Tests/Extensibility/Extensions/WebSequenceDiagramsTests.cs
@@ -1,0 +1,61 @@
+﻿using Pretzel.Logic.Extensibility.Extensions;
+using Xunit;
+
+namespace Pretzel.Tests.Extensibility.Extensions
+{
+    public class WebSequenceDiagramsTests
+    {
+        readonly WebSequenceDiagrams transform = new WebSequenceDiagrams();
+
+        [Fact]
+        public void Single_block_is_converted_to_diagram()
+        {
+            const string input = @"<p>hello</p>
+<pre><code>@@sequence
+a->b: foo
+b->a: bar
+</code></pre>
+<p>world</p>";
+
+            const string expected = @"<p>hello</p>
+<div class=""wsd"" wsd_style=""""><pre>a->b: foo
+b->a: bar
+</pre></div>
+<p>world</p>
+<script type=""text/javascript"" src=""http://www.websequencediagrams.com/service.js""></script>";
+
+            var markdown = transform.Transform(input);
+            Assert.Equal(expected, markdown);
+        }
+
+        [Fact]
+        public void Multiple_blocks_are_converted_to_multiple_diagrams()
+        {
+            const string input = @"<p>hello</p>
+<pre><code>@@sequence
+a->b: foo
+b->a: bar
+</code></pre>
+<p>world</p>
+<pre><code>@@sequence
+c->d: baz
+d->c: qak
+</code></pre>
+<p>woo</p>";
+
+            const string expected = @"<p>hello</p>
+<div class=""wsd"" wsd_style=""""><pre>a->b: foo
+b->a: bar
+</pre></div>
+<p>world</p>
+<div class=""wsd"" wsd_style=""""><pre>c->d: baz
+d->c: qak
+</pre></div>
+<p>woo</p>
+<script type=""text/javascript"" src=""http://www.websequencediagrams.com/service.js""></script>";
+
+            var markdown = transform.Transform(input);
+            Assert.Equal(expected, markdown);
+        }
+    }
+}

--- a/src/Pretzel.Tests/Pretzel.Tests.csproj
+++ b/src/Pretzel.Tests/Pretzel.Tests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="CommandParameterOutputTests.cs" />
     <Compile Include="CommandParameterTests.cs" />
+    <Compile Include="Extensibility\Extensions\WebSequenceDiagramsTests.cs" />
     <Compile Include="Import\BloggerImportTests.cs" />
     <Compile Include="Import\HtmlToMarkdownConverterTests.cs" />
     <Compile Include="Import\WordpressImportTests.cs" />


### PR DESCRIPTION
The regex was too greedy, resulting in whole chunks of the page being wrapped in one big wsd div instead of separate ones for each diagram. Also, there was no test.
