### PR TITLE
Stop crashing when timestamps in filenames are invalid

### DIFF
--- a/src/Pretzel.Logic/Extensions/StringExtensions.cs
+++ b/src/Pretzel.Logic/Extensions/StringExtensions.cs
@@ -547,11 +547,14 @@ namespace Pretzel.Logic.Extensions
         {
             var fileName = file.Substring(file.LastIndexOf("\\"));
             var tokens = fileName.Split('-');
+
             if (tokens.Count() < 3)
                 return DateTime.Now;
 
-            var timestamp = string.Join("-", tokens.Take(3)).Trim('\\');
-            return DateTime.Parse(timestamp);
+            var timestampText = string.Join("-", tokens.Take(3)).Trim('\\');
+
+            DateTime timestamp;
+            return DateTime.TryParse(timestampText, out timestamp) ? timestamp : DateTime.Now;
         }
     }
 }

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using MarkdownDeep;
 using Pretzel.Logic.Extensibility;
 using Pretzel.Logic.Extensions;
@@ -328,19 +329,10 @@ namespace Pretzel.Logic.Templating.Context
             return Path.Combine(outputDirectory, timestamp, title);
         }
 
-        private string GetTitle(string file)
+        static readonly Regex TimestampAndTitleFromPathRegex = new Regex(@"\\(?:(?<timestamp>\d+-\d+-\d+)-)?(?<title>[^\\]*)\.[^\.]+$");
+        public static string GetTitle(string file)
         {
-            // TODO: detect mode from site config
-            var fileName = file.Substring(file.LastIndexOf("\\"));
-
-            var tokens = fileName.Split('-');
-            if (tokens.Length < 3)
-            {
-                return fileName.Substring(1, fileName.LastIndexOf(".") - 1);
-            }
-            var title = string.Join("-", tokens.Skip(3));
-            title = title.Substring(0, title.LastIndexOf("."));
-            return title;
+            return TimestampAndTitleFromPathRegex.Match(file).Groups["title"].Value;
         }
         private string GetPageTitle(string file)
         {

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -233,5 +233,26 @@ title: Title
             Assert.Equal(1, cat4.Posts.First().Categories.Count());
             Assert.True(cat4.Posts.First().File.Contains("File3"));
         }
+
+        [Fact]
+        public void GetTitle_returns_original_value_when_no_timestamp()
+        {
+            var result = SiteContextGenerator.GetTitle(@"C:\temp\foobar_baz.md");
+            Assert.Equal("foobar_baz", result);
+        }
+
+        [Fact]
+        public void GetTitle_returns_strips_timestamp()
+        {
+            var result = SiteContextGenerator.GetTitle(@"C:\temp\2012-01-03-foobar_baz.md");
+            Assert.Equal("foobar_baz", result);
+        }
+
+        [Fact]
+        public void GetTitle_preserves_dash_separated_values_that_arent_timestamps()
+        {
+            var result = SiteContextGenerator.GetTitle(@"C:\temp\foo-bar-baz-qak-foobar_baz.md");
+            Assert.Equal("foo-bar-baz-qak-foobar_baz", result);
+        }
     }
 }


### PR DESCRIPTION
Test and fix to stop filenames like `c:\foo\bar-baz-qak.md` from crashing Pretzel all together
