### PR TITLE
Only wait for key press if we can (currently crash when redirecting outp...

### DIFF
--- a/src/Pretzel/Program.cs
+++ b/src/Pretzel/Program.cs
@@ -74,7 +74,8 @@ namespace Pretzel
         public void WaitForClose()
         {
             Console.WriteLine("Press any key to continue...");
-            Console.ReadKey();
+            if (Console.KeyAvailable)
+                Console.ReadKey();
         }
 
         public void Compose()


### PR DESCRIPTION
...ut on build server)
