### PR TITLE
Fix crash on build server

### DIFF
--- a/src/Pretzel/Program.cs
+++ b/src/Pretzel/Program.cs
@@ -74,7 +74,14 @@ namespace Pretzel
         public void WaitForClose()
         {
             Console.WriteLine("Press any key to continue...");
-            Console.ReadKey();
+            try
+            {
+                Console.ReadKey();
+            }
+            catch (InvalidOperationException)
+            {
+                //Output is redirected, we don't care to keep console open just let it close
+            }
         }
 
         public void Compose()


### PR DESCRIPTION
[16:04:14][Step 1/2] Unhandled Exception: System.InvalidOperationException: Cannot read keys when either application does not have a console or when console input has been redirected from a file. Try Console.Read.
[16:04:14][Step 1/2]    at System.Console.ReadKey(Boolean intercept)
[16:04:14][Step 1/2]    at System.Console.ReadKey()

Lets just ignore the exception, then let the app exit
