### PR TITLE
Updated the way the Wordpress Importer treats the date property

### DIFF
--- a/src/Pretzel.Logic/Import/WordpressImport.cs
+++ b/src/Pretzel.Logic/Import/WordpressImport.cs
@@ -55,7 +55,7 @@ namespace Pretzel.Logic.Import
             var header = new
             {
                 title = p.Title,
-                date = p.Published,
+                date = p.Published.ToString("yyyy-MM-dd"),
                 layout = "post",
                 categories = p.Categories,
                 tags = p.Tags


### PR DESCRIPTION
Currently when a post is generated using the wordpress importer, the date property of the post outputs the entire DateTime's set of C# properties. I've updated it to only output the format "yyyy-MM-dd".
