### PR TITLE
Don't skip .htaccess file

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -157,7 +157,7 @@ namespace Pretzel.Logic.Templating.Context
 
         private static bool IsSpecialPath(string relativePath)
         {
-            return relativePath.StartsWith("_") || relativePath.StartsWith(".");
+            return relativePath.StartsWith("_") || (relativePath.StartsWith(".") && relativePath != ".htaccess");
         }
 
         private Page CreatePage(SiteContext context, IDictionary<string, object> config, string file, bool isPost)


### PR DESCRIPTION
.htaccess is a file used by the Apache web server to control redirects among other things. Previously pretzel ignored .htaccess files as they start with a period.
