### PR TITLE
Fixed failing tests and use of -d for directory paths. 

### DIFF
--- a/src/Pretzel.Logic/Commands/CommandParameters.cs
+++ b/src/Pretzel.Logic/Commands/CommandParameters.cs
@@ -82,6 +82,10 @@ namespace Pretzel.Logic.Commands
             {
                 Path = Directory.GetCurrentDirectory();
             }
+            else
+            {
+                Path = System.IO.Path.GetFullPath(Path);
+            }
         }
 
         public void DetectFromDirectory(IDictionary<string, ISiteEngine> engines, SiteContext context)

--- a/src/Pretzel.Logic/Import/BloggerImport.cs
+++ b/src/Pretzel.Logic/Import/BloggerImport.cs
@@ -54,7 +54,7 @@ namespace Pretzel.Logic.Import
                         {
                             Title = e.Element(atom + "title").Value,
                             //PostName = e.Element(wp + "post_name").Value,
-                            Published = Convert.ToDateTime(e.Element(atom + "published").Value),
+                            Published = Convert.ToDateTime(e.Element(atom + "published").Value).ToUniversalTime(),
                             Updated = Convert.ToDateTime(e.Element(atom + "updated").Value),
                             Content = ConvertToMarkdown(e.Element(atom + "content").Value),
                             /*Tags = from t in e.Elements(atom + "category")

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -187,10 +187,7 @@ namespace Pretzel.Logic.Templating.Context
                 if (header.ContainsKey("permalink"))
                     page.Url = EvaluatePermalink(header["permalink"].ToString(), page);
                 else if (config.ContainsKey("permalink"))
-                {
                     page.Url = EvaluatePermalink(config["permalink"].ToString(), page);
-                    page.Bag.Add("permalink", config["permalink"].ToString());
-                }
 
                 // The GetDirectoryPage method is reentrant, we need a cache to stop a stack overflow :)
                 pageCache.Add(file, page);


### PR DESCRIPTION
fixed a problem where the blogger import tests fail if not on the other
side of the date line.  This should fix issue #115

fixed directory pathing if you pass in the -d parameter. It was creating
duplicate levels on bake within -d
