### PR TITLE
If content fails to go through templating engine, just fall back to cont...

### DIFF
--- a/src/Pretzel.Logic/Templating/Razor/RazorSiteEngine.cs
+++ b/src/Pretzel.Logic/Templating/Razor/RazorSiteEngine.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using System.IO;
 using System.Text.RegularExpressions;
 using Pretzel.Logic.Templating.Context;
@@ -36,8 +37,15 @@ namespace Pretzel.Logic.Templating.Razor
            RazorEngine.Razor.SetTemplateService(new TemplateService(serviceConfig));
 
            content = Regex.Replace(content, "<p>(@model .*?)</p>", "$1");
-
-           return RazorEngine.Razor.Parse(content, pageData);
+            try
+            {
+                return RazorEngine.Razor.Parse(content, pageData);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine(@"Failed to render template, falling back to direct content");
+                return content;
+            }
         }
     }
 }

--- a/src/Pretzel.Tests/Templating/Razor/RazorEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Razor/RazorEngineTests.cs
@@ -100,10 +100,11 @@ namespace Pretzel.Tests.Templating.Razor
         {
             const string templateContents = "<html><head><title>@Model.Title</title></head><body>@Raw(Model.Content)</body></html>";
             const string pageContents = "<i>@Include(\"TestInclude\")</i>";
+            const string expectedfileContents = "<html><head><title>My Web Site</title></head><body><i>@Include(\"TestInclude\")</i></body></html>";
+            ProcessContents(templateContents, pageContents, new Dictionary<string, object> {{"title", "My Web Site"}});
 
-            Assert.ThrowsDelegate action = () => ProcessContents(templateContents, pageContents, new Dictionary<string, object> {{"title", "My Web Site"}});
-
-            Assert.Throws<PageProcessingException>(action);
+            var output = FileSystem.File.ReadAllText(@"C:\website\_site\index.html");
+            Assert.Equal(expectedfileContents, output);
         }
 
         [Fact]


### PR DESCRIPTION
...ent before it went through template engine

I had a markdown file, with code in it which razorengine fails to render. By this point the template has already been rendered, and the content injected. This is the second pass after the content is already in the file which fails.

I figure it is fine to just swallow the exception, and output the file as is.
