### PR TITLE
fix for written files to respect permalink in _config.yml

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/PageContext.cs
+++ b/src/Pretzel.Logic/Templating/Context/PageContext.cs
@@ -25,13 +25,21 @@ namespace Pretzel.Logic.Templating.Context
         }
 
         public string Title { get; set; }
+
         public string OutputPath { get; set; }
+
         public IDictionary<string, object> Bag { get; set; }
+
         public string Content { get; set; }
+
         public SiteContext Site { get; private set; }
+
         public Page Page { get; set; }
+
         public Page Previous { get; set; }
+
         public Page Next { get; set; }
+
         public Paginator Paginator { get; set; }
 
         public bool Comments
@@ -43,7 +51,7 @@ namespace Pretzel.Logic.Templating.Context
         {
             var context = new PageContext(siteContext, page);
 
-            if (page.Bag.ContainsKey("permalink"))
+            if (page.Bag.ContainsKey("permalink") || siteContext.Config.ContainsKey("permalink"))
             {
                 context.OutputPath = Path.Combine(outputPath, page.Url.ToRelativeFile());
             }

--- a/src/Pretzel.Tests/Templating/Context/PageContextTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/PageContextTests.cs
@@ -1,0 +1,74 @@
+﻿using Pretzel.Logic.Templating.Context;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Pretzel.Tests.Templating.Context
+{
+    public class PageContextTests
+    {
+        [Fact]
+        public void config_permalink_sets_relative_file_output_path()
+        {
+            var context = new SiteContext();
+            context.Config = new Dictionary<string, object>();
+            context.Config.Add("permalink", "/blog/:year/:month/:day/:title.html");
+
+            var page = new Page()
+            {
+                Url = "/blog/2010/08/21/title-of-my-post.html"
+            };
+
+            var outputPath = "c:\\temp";
+            var defaultOutputPath = "c:\\default";
+
+            var pageContext = PageContext.FromPage(context, page, outputPath, defaultOutputPath);
+
+            Assert.Equal("c:\\temp\\blog\\2010\\08\\21\\title-of-my-post.html", pageContext.OutputPath);
+        }
+
+        [Fact]
+        public void page_permalink_sets_relative_file_output_path()
+        {
+            var context = new SiteContext();
+            context.Config = new Dictionary<string, object>();
+
+            var page = new Page()
+            {
+                Url = "/blog/2010/08/21/title-of-my-post.html"
+            };
+
+            page.Bag = new Dictionary<string, object>();
+            page.Bag.Add("permalink", "/blog/:year/:month/:day/:title.html");
+
+            var outputPath = "c:\\temp";
+            var defaultOutputPath = "c:\\default";
+
+            var pageContext = PageContext.FromPage(context, page, outputPath, defaultOutputPath);
+
+            Assert.Equal("c:\\temp\\blog\\2010\\08\\21\\title-of-my-post.html", pageContext.OutputPath);
+        }
+
+        [Fact]
+        public void no_permalink_sets_default_output_path_and_page_bag_permalink()
+        {
+            var context = new SiteContext();
+            context.Config = new Dictionary<string, object>();
+
+            var file = "title-of-my-post.html";
+            var page = new Page()
+            {
+                File = file
+            };
+
+            page.Bag = new Dictionary<string, object>();
+
+            var outputPath = "c:\\temp";
+            var defaultOutputPath = "c:\\default\\title-of-my-post.html";
+
+            var pageContext = PageContext.FromPage(context, page, outputPath, defaultOutputPath);
+
+            Assert.Equal("c:\\default\\title-of-my-post.html", pageContext.OutputPath);
+            Assert.Equal(file, page.Bag["permalink"]);
+        }
+    }
+}


### PR DESCRIPTION
I made a fix for an issue where the generated folders under _site were not respecting the configured permalink in _config.yml.

Given this example config:

```
permalink: /blog/:year/:month/:day/:title
pretzel: 
    engine: liquid
```

Under _site, no /blog folder was being created, and the .html extension was not being removed from files. The post-level permalink was working fine, but the _config.yml permalink wasn't being used.

I added a few tests for PageContext that cover this fix.
