### PR TITLE
Fixes huge startup time when pages contain css references that uses relative protocol.

### DIFF
--- a/src/Pretzel.Logic/Minification/LessTransform.cs
+++ b/src/Pretzel.Logic/Minification/LessTransform.cs
@@ -53,9 +53,12 @@ namespace Pretzel.Logic.Minification
                     foreach(HtmlNode link in nodes)
                     {
                         var cssfile = link.Attributes["href"].Value;
-                        if (cssfile.StartsWith("http"))
-                            continue;
 
+                        // If the file is not local, ignore it
+                        var matchingIgnoreProtocol = new[] {"http", "https", "//"}.FirstOrDefault(cssfile.StartsWith);
+                        if(matchingIgnoreProtocol != null)
+                            continue;
+                        
                         //If the file exists, ignore it
                         if (File.Exists(Path.Combine(siteContext.OutputFolder, cssfile)))
                             continue;


### PR DESCRIPTION
My <style href="//domain.com/style.css" /> tag caused huge startup time because File.Exists() waits for timeout before returning false. This fixes it.
