### PR TITLE
#Add support for :categories in permalink. & #Fix double-configuration bug ...

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -185,7 +185,18 @@ namespace Pretzel.Logic.Templating.Context
                                     File = file,
                                     Bag = header,
                                 };
+                
+                // resolve categories and tags
+                if (isPost)
+                {
+                    if (header.ContainsKey("categories"))
+                        page.Categories = header["categories"] as IEnumerable<string>;
 
+                    if (header.ContainsKey("tags"))
+                        page.Tags = header["tags"] as IEnumerable<string>;
+                }
+
+                // resolve permalink
                 if (header.ContainsKey("permalink"))
                     page.Url = EvaluatePermalink(header["permalink"].ToString(), page);
                 else if (isPost && config.ContainsKey("permalink"))
@@ -197,14 +208,6 @@ namespace Pretzel.Logic.Templating.Context
                 pageCache.Add(file, page);
                 page.DirectoryPages = GetDirectoryPages(context, config, Path.GetDirectoryName(file), isPost).ToList();
 
-                if (isPost)
-                {
-                    if (header.ContainsKey("categories"))
-                        page.Categories = header["categories"] as IEnumerable<string>;
-
-                    if (header.ContainsKey("tags"))
-                        page.Tags = header["tags"] as IEnumerable<string>;
-                }
                 return page;
             }
             catch (Exception e)
@@ -332,10 +335,13 @@ namespace Pretzel.Logic.Templating.Context
         // https://github.com/mojombo/jekyll/wiki/permalinks
         private string EvaluatePermalink(string permalink, Page page)
         {
+            permalink = permalink.Replace(":categories", string.Join("-", page.Categories.ToArray()));
             permalink = permalink.Replace(":year", page.Date.Year.ToString(CultureInfo.InvariantCulture));
             permalink = permalink.Replace(":month", page.Date.ToString("MM"));
             permalink = permalink.Replace(":day", page.Date.ToString("dd"));
             permalink = permalink.Replace(":title", GetTitle(page.File));
+
+            permalink = permalink.Replace("//", "/");
 
             return permalink;
         }

--- a/src/Pretzel.Logic/Templating/Jekyll/SiteContextDrop.cs
+++ b/src/Pretzel.Logic/Templating/Jekyll/SiteContextDrop.cs
@@ -39,12 +39,12 @@ namespace Pretzel.Logic.Templating.Jekyll.Liquid
             if (!context.Config.ContainsKey("date"))
                 context.Config.Add("date", "2012-01-01");
             var x = Hash.FromDictionary(context.Config);
-            x.Add("posts", Posts);
-            x.Add("pages", context.Pages);
-            x.Add("title", context.Title);
-            x.Add("tags", context.Tags);
-            x.Add("categories", context.Categories);
-            x.Add("time", Time);
+            x["posts"] = Posts;
+            x["pages"] = context.Pages;
+            x["title"] = context.Title;
+            x["tags"] = context.Tags;
+            x["categories"] = context.Categories;
+            x["time"] = Time;
 
             return x;
         }


### PR DESCRIPTION
Two things are addressed in this commit:
#1. Support for :categories in permalink. First of all no string replacing was happening for categories and also the resolution of categories and tags (in CreatePage) was happening after the resolution of permalink. -- which is too late so moved to before that
#2. In siteContextDrop the code to ToHash was always adding to dictionary while it is likely that a key is present both in the "config" and the "context" itself.

Note: I noticed these issues while trying to get the "jekyll bootstrap template" building with this tool. -- template can be found here: https://github.com/plusjade/jekyll-bootstrap/
