### PR TITLE
Update Sitemap.liquid

### DIFF
--- a/src/Pretzel.Logic/Resources/Liquid/Sitemap.liquid
+++ b/src/Pretzel.Logic/Resources/Liquid/Sitemap.liquid
@@ -11,11 +11,21 @@ layout: nil
   
   {% for post in site.posts %}
   <url>
-    <loc>http://domain/{{ post.url }}</loc>
+    <loc>http://domain{{ post.url }}</loc>
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>
+  {% endfor %}
+  
+  {% for page in site.pages %}
+	{% if page.url %}
+	<url>
+		<loc>http://domain{{ page.url }}</loc>
+		<changefreq>daily</changefreq>
+		<priority>1.00</priority>
+	</url>
+	{% endif %}
   {% endfor %}
   
 </urlset>


### PR DESCRIPTION
Include the 'normal' pages in the sitemap and not just the blog posts. And remove the trailing / that makes the url prefixed with 2 slashes
