### PR TITLE
Create command fixes

### DIFF
--- a/src/Pretzel.Logic/Recipe/Recipe.cs
+++ b/src/Pretzel.Logic/Recipe/Recipe.cs
@@ -10,7 +10,7 @@ namespace Pretzel.Logic.Recipe
 {
     public class Recipe
     {
-        public Recipe(IFileSystem fileSystem, string engine, string directory, IEnumerable<IAdditionalIngredient> additionalIngredients, bool withProject, bool wiki)
+        public Recipe(IFileSystem fileSystem, string engine, string directory, IEnumerable<IAdditionalIngredient> additionalIngredients, bool withProject, bool wiki, bool withDrafts = false)
         {
             this.fileSystem = fileSystem;
             this.engine = engine;
@@ -18,6 +18,7 @@ namespace Pretzel.Logic.Recipe
             this.additionalIngredients = additionalIngredients;
             this.withProject = withProject;
             this.wiki = wiki;
+            this.withDrafts = withDrafts;
         }
 
         private readonly IFileSystem fileSystem;
@@ -26,6 +27,7 @@ namespace Pretzel.Logic.Recipe
         private readonly IEnumerable<IAdditionalIngredient> additionalIngredients;
         private readonly bool withProject;
         private readonly bool wiki;
+        private readonly bool withDrafts;
 
         public void Create()
         {
@@ -161,6 +163,9 @@ namespace Pretzel.Logic.Recipe
             fileSystem.Directory.CreateDirectory(Path.Combine(directory, @"_layouts"));
             fileSystem.Directory.CreateDirectory(Path.Combine(directory, @"css"));
             fileSystem.Directory.CreateDirectory(Path.Combine(directory, @"img"));
+            if (withDrafts) {
+                fileSystem.Directory.CreateDirectory(Path.Combine(directory, @"_drafts"));
+            }
         }
     }
 }

--- a/src/Pretzel.Logic/Resources/Liquid/Sitemap.liquid
+++ b/src/Pretzel.Logic/Resources/Liquid/Sitemap.liquid
@@ -11,7 +11,7 @@ layout: nil
   
   {% for post in site.posts %}
   <url>
-    <loc>http://domain/{{ post.url }}</id>
+    <loc>http://domain/{{ post.url }}</loc>
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>

--- a/src/Pretzel.Logic/Resources/Razor/Index.cshtml
+++ b/src/Pretzel.Logic/Resources/Razor/Index.cshtml
@@ -51,7 +51,7 @@ title : SiteName
 
 <h3>OLDER</h3>
 <ul class="postArchive">
-@foreach(var post in Model.Site.Posts.Skip(5))
+@foreach(var post in Model.Site.Posts.Skip(numberPosts))
 {
     <li>
         <span class="olderpostdate">@post.Date.ToString("d m")</span> <a class="postlink" href="@post.Url">@post.Title</a>

--- a/src/Pretzel.Logic/Resources/Razor/Rss.cshtml
+++ b/src/Pretzel.Logic/Resources/Razor/Rss.cshtml
@@ -17,10 +17,10 @@ layout: nil
     {
         <item>
             <title>@post.Title</title>
-            <link>http://domain@post.Url</link>
+            @Raw("<link>")http://domain@(post.Url)@Raw("</link>") @* Workaround: RazorEngine is a HTML5 template engine, where link is a void element *@	
             <pubDate>@post.Date.ToString("ddd, dd MMM yyyy H:mm:ss K")</pubDate>
             <author>Author</author>
-            <guid>http://domain@post.Url</guid>
+            <guid>http://domain@(post.Url)</guid>
             <description>@post.Content</description>
         </item>
     }

--- a/src/Pretzel.Logic/Resources/Razor/Sitemap.cshtml
+++ b/src/Pretzel.Logic/Resources/Razor/Sitemap.cshtml
@@ -13,7 +13,7 @@ layout: nil
     @foreach (var post in Model.Site.Posts)
     {
         <url>
-            <loc>http://domain/@post.Url</id>
+            <loc>http://domain/@post.Url</loc>
             <lastmod>@post.Date.ToString("s")</lastmod>
             <changefreq>daily</changefreq>
             <priority>1.00</priority>

--- a/src/Pretzel/Commands/RecipeCommand.cs
+++ b/src/Pretzel/Commands/RecipeCommand.cs
@@ -41,7 +41,7 @@ namespace Pretzel.Commands
 
             Tracing.Info(string.Format("Using {0} Engine", engine));
 
-            var recipe = new Recipe(fileSystem, engine, parameters.Path, additionalIngredients, parameters.WithProject, parameters.Wiki);
+            var recipe = new Recipe(fileSystem, engine, parameters.Path, additionalIngredients, parameters.WithProject, parameters.Wiki, parameters.IncludeDrafts);
             recipe.Create();
         }
 


### PR DESCRIPTION
Some minor fixes to the `create` command not working as expected out of the box templates did not transform for default freshly created site: RSS and Sitemap template fixes.
`--drafts` was ignored in `create` althoug listed at the command line help. Now it creates (empty) `drafts` folder

(partially) fixes issue #173 reported by me for these problems.