### PR TITLE
Ensure date present in page hash. Fixes #59.

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -219,6 +219,12 @@ namespace Pretzel.Logic.Templating.Context
                 else
                     page.Url = EvaluateLink(context, page);
 
+                // ensure the date is accessible in the hash
+                if(!page.Bag.ContainsKey("date")) 
+                {
+                    page.Bag["date"] = page.Date;
+                }
+
                 // The GetDirectoryPage method is reentrant, we need a cache to stop a stack overflow :)
                 pageCache.Add(file, page);
                 page.DirectoryPages = GetDirectoryPages(context, config, Path.GetDirectoryName(file), isPost).ToList();

--- a/src/Pretzel.Tests/Pretzel.Tests.csproj
+++ b/src/Pretzel.Tests/Pretzel.Tests.csproj
@@ -114,7 +114,9 @@
       <Name>Pretzel.Logic</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Pretzel.Logic.Extensibility;
 using Pretzel.Logic.Templating.Context;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Pretzel.Tests.Templating.Context
 {
@@ -305,6 +306,33 @@ title: Title
 
             // assert
             Assert.Equal(2, siteContext.Posts.Count);
+        }
+
+        [Theory]
+        [InlineData(@"C:\TestSite\2014-01-01-ByFilename.md", false)]
+        [InlineData(@"C:\TestSite\UsingDefault.md", true)]
+        public void site_context_pages_have_date_in_bag(string fileName, bool useDefault) 
+        {
+
+            // note - this test does not include the time component.
+
+            // arrange
+            var expectedDate = useDefault
+                ? DateTime.Now.ToString("yyyy-MM-dd")
+                : "2014-01-01";
+
+            fileSystem.AddFile(fileName, new MockFileData(ToPageContent("# Title")));
+
+            // act
+            var siteContext = generator.BuildContext(@"C:\TestSite", false);
+
+            // assert 
+            Assert.True(siteContext.Pages[0].Bag.ContainsKey("date"));
+            Assert.IsType<DateTime>(siteContext.Pages[0].Bag["date"]);
+
+            var actualDate = ((DateTime)siteContext.Pages[0].Bag["date"]).ToString("yyyy-MM-dd");
+
+            Assert.Equal(expectedDate, actualDate);
         }
     }
 }


### PR DESCRIPTION
Issue #59 still seemed to be broken in the latest source - specifically when page dates come from the file name rather than the header. 

Updated SiteContextGenerator.CreatePage to add the date to the page's bag if it is not already present, and added test cases to SiteContextGeneratorTests.
