### PR TITLE
Handle bool in yaml

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,42 @@
+ 
+# In development
+
+## Breaking changes
+- [#189](https://github.com/Code52/pretzel/pull/189): Handle bool in yaml
+In a YAML frontmatter like the following:
+``` text
+-------
+active: true
+-------
+``` 
+Recognize that the value of "active" is a boolean and convert it in the datas for DotLiquid so that it is possible to use it in a template like that:
+```cs
+{% if page.active == true %}
+```
+Like in Jekyll.
+ 
+But this will cause a breaking change if anyone have a
+```cs
+{% if page.active == 'true' %}
+```
+in a template.
+ 
+## Features
+- [#181](https://github.com/Code52/pretzel/pull/181): Added new Jekyll filters and tags by [switchspan](https://github.com/switchspan)
+    - DateToLongStringFilter
+    - DateToStringFilter
+    - NumberOfWordsFilter
+    - CgiEscapeFilter
+    - UriEscapeFilter
+    - CommentBlock
+    - PostUrlBlock
+ 
+- [#185](https://github.com/Code52/pretzel/pull/185): Allow all *.md, *.mkd, *.mkdn, *.mdown and *.markdown files to be processed
+ 
+- Add a cleantarget argument which deletes the target directory (_site), like Jekyll does by default
+- Improve less compilation
+- Add include and exclude configuration features, like in [Jekyll](http://jekyllrb.com/docs/configuration/#global-configuration)
+- [#189](https://github.com/Code52/pretzel/pull/189): Add support for category in page permalinks by [dkarzon](https://github.com/dkarzon)
+
+## Fixes
+- Fix issue where transforms aren't processed during taste => fix the .less not compiled during taste for example

--- a/src/Pretzel.Logic/Extensions/YamlExtensions.cs
+++ b/src/Pretzel.Logic/Extensions/YamlExtensions.cs
@@ -84,6 +84,12 @@ namespace Pretzel.Logic.Extensions
                 return listResults;
             }
 
+            bool valueBool;
+            if (bool.TryParse(value.ToString(), out valueBool))
+            {
+                return valueBool;
+            }
+
             return value.ToString();
         }
 

--- a/src/Pretzel.Logic/Resources/Liquid/Post.liquid
+++ b/src/Pretzel.Logic/Resources/Liquid/Post.liquid
@@ -20,7 +20,7 @@ layout: layout
 </div> 
 
 
-{% if page.comments %}
+{% if page.comments == true %}
 <div id="disqus_thread"></div>
 <script type="text/javascript">
     /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */

--- a/src/Pretzel.Tests/YamlExtensionsTests.cs
+++ b/src/Pretzel.Tests/YamlExtensionsTests.cs
@@ -100,6 +100,27 @@ This is a test of YAML parsing
                 Assert.Equal("alsotest", tags[1]);
                 Assert.Equal("lasttest", tags[2]);
             }
+
+            [Fact]
+            public void YamlHeader_WithSampleData_HandleBoolean()
+            {
+                const string header = @"---
+                        active: true
+                        comments: false
+                        other: 'true'
+                        ---
+            
+                        ##Test
+            
+                        This is a test of YAML parsing";
+
+                var result = header.YamlHeader();
+
+                Assert.True((bool)result["active"]);
+                Assert.False((bool)result["comments"]);
+                Assert.Equal("True", result["other"].ToString());
+            }
+
         }
     }
 }


### PR DESCRIPTION
In a YAML frontmatter like the following:
``` text
-------
active: true
-------
```
Recognize that the value of "active" is a boolean and convert it in the datas for DotLiquid so that it is possible to use it in a template like that:
```cs
{% if page.active == true %}
```
Like in Jekyll.

But this will cause a breaking change if anyone have a 
```cs
{% if page.active == 'true' %}
```
in a template.

@shiftkey, @JakeGinnivan what do you think?
Is it a big problem or a release note could be sufficient?