### PR TITLE
Fix WebSequenceDiagram style bug:the style was not used

### DIFF
--- a/src/Pretzel.Logic/Extensibility/Extensions/WebSequenceDiagrams.cs
+++ b/src/Pretzel.Logic/Extensibility/Extensions/WebSequenceDiagrams.cs
@@ -5,6 +5,9 @@ namespace Pretzel.Logic.Extensibility.Extensions
     public class WebSequenceDiagrams : IContentTransform
     {
         static readonly Regex SequenceDiagramRegex = new Regex(@"(?s:<pre><code>@@sequence(?<style>.*?)\r?\n(?<sequenceContent>.*?)</code></pre>)");
+        const string Style_Template = " wsd_style=\"{0}\"";
+        const string Div_Template = "<div class=\"wsd\"{1}><pre>{0}</pre></div>";
+        const string JS_Script = "\r\n<script type=\"text/javascript\" src=\"http://www.websequencediagrams.com/service.js\"></script>";
 
         public string Transform(string content)
         {
@@ -14,16 +17,19 @@ namespace Pretzel.Logic.Extensibility.Extensions
                 contentIncludesASequenceDiagram = true;
                 var sequenceContent = match.Groups["sequenceContent"].Value;
                 var styleGroup = match.Groups["style"];
-                string style;
-                if (styleGroup.Success && string.IsNullOrWhiteSpace(styleGroup.Value))
-                    style = string.Format(" wsd_style=\"{0}\"", styleGroup.Value);
-                else
-                    style = string.Empty;
-                return string.Format("<div class=\"wsd\"{1}><pre>{0}</pre></div>", sequenceContent, style);
+                string style = "default";
+                if (styleGroup.Success && !string.IsNullOrWhiteSpace(styleGroup.Value))
+                {
+                    style = styleGroup.Value.Trim();
+                }
+
+                return string.Format(Div_Template, sequenceContent, string.Format(Style_Template, style));
             });
 
             if (contentIncludesASequenceDiagram)
-                content += "\r\n<script type=\"text/javascript\" src=\"http://www.websequencediagrams.com/service.js\"></script>";
+            { 
+                content += JS_Script;
+            }
 
             return content;
         }

--- a/src/Pretzel.Tests/Extensibility/Extensions/WebSequenceDiagramsTests.cs
+++ b/src/Pretzel.Tests/Extensibility/Extensions/WebSequenceDiagramsTests.cs
@@ -19,7 +19,7 @@ b->a: bar
 <p>world</p>";
 
             const string expected = @"<p>hello</p>
-<div class=""wsd"" wsd_style=""""><pre>a->b: foo
+<div class=""wsd"" wsd_style=""default""><pre>a->b: foo
 b->a: bar
 </pre></div>
 <p>world</p>
@@ -45,14 +45,35 @@ d->c: qak
 <p>woo</p>";
 
             const string expected = @"<p>hello</p>
-<div class=""wsd"" wsd_style=""""><pre>a->b: foo
+<div class=""wsd"" wsd_style=""default""><pre>a->b: foo
 b->a: bar
 </pre></div>
 <p>world</p>
-<div class=""wsd"" wsd_style=""""><pre>c->d: baz
+<div class=""wsd"" wsd_style=""default""><pre>c->d: baz
 d->c: qak
 </pre></div>
 <p>woo</p>
+<script type=""text/javascript"" src=""http://www.websequencediagrams.com/service.js""></script>";
+
+            var markdown = transform.Transform(input);
+            Assert.Equal(expected.RemoveWhiteSpace(), markdown.RemoveWhiteSpace());
+        }
+
+        [Fact]
+        public void Single_block_is_converted_to_diagram_style_mscgen()
+        {
+            const string input = @"<p>hello</p>
+<pre><code>@@sequence mscgen
+a->b: foo
+b->a: bar
+</code></pre>
+<p>world</p>";
+
+            const string expected = @"<p>hello</p>
+<div class=""wsd"" wsd_style=""mscgen""><pre>a->b: foo
+b->a: bar
+</pre></div>
+<p>world</p>
 <script type=""text/javascript"" src=""http://www.websequencediagrams.com/service.js""></script>";
 
             var markdown = transform.Transform(input);


### PR DESCRIPTION
Now the default style is really 'default', like indicated on https://www.websequencediagrams.com/embedding.html.
And with "@@sequence style", 'style' will replace 'default'.