### PR TITLE
Support for 404 pages

### DIFF
--- a/src/Pretzel/WebHost/WebHost.cs
+++ b/src/Pretzel/WebHost/WebHost.cs
@@ -68,10 +68,20 @@ namespace Pretzel
 
             if (!content.IsAvailable(path))
             {
-                var response = new Response(env) { ContentType = path.MimeType() };
+                var path404 = "/404.html";
+                var use404 = content.IsAvailable(path404);
+
+                var response = new Response(env) { ContentType = use404 ? path404.MimeType() : path.MimeType() };
                 using (var writer = new StreamWriter(response.OutputStream))
                 {
-                    writer.Write("Page not found: " + path);
+                    if (use404)
+                    {
+                        writer.Write(content.GetContent(path404));
+                    }
+                    else
+                    {
+                        writer.Write("Page not found: " + path);
+                    }
                 }
                 return TaskHelpers.Completed();
             }


### PR DESCRIPTION
This is more a feature of Github pages than Jekyll itself but adding support for custom 404 pages from the Pretzel web host.
https://help.github.com/articles/custom-404-pages/
If there is a 404.html file in the site it will server that when it can't find the correct content.
