### PR TITLE
Better support for exclude config setting

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -44,20 +44,9 @@ namespace Pretzel.Logic.Templating.Context
                 if (!config.ContainsKey("permalink"))
                     config.Add("permalink", "/:year/:month/:day/:title.html");
 
-                if (config.ContainsKey("pretzel"))
+                if (config.ContainsKey("include"))
                 {
-                    var pretzelSettings = config["pretzel"] as Dictionary<string, object>;
-                    if (pretzelSettings != null)
-                    {
-                        if (pretzelSettings.ContainsKey("include") && includes.Count == 0)
-                        {
-                            includes.AddRange((IEnumerable<string>)pretzelSettings["include"]);
-                        }
-                        if (pretzelSettings.ContainsKey("exclude") && excludes.Count == 0)
-                        {
-                            excludes.AddRange((IEnumerable<string>)pretzelSettings["exclude"]);
-                        }
-                    }
+                    includes.AddRange((IEnumerable<string>)config["include"]);
                 }
                 if (config.ContainsKey("exclude"))
                 {

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -59,6 +59,10 @@ namespace Pretzel.Logic.Templating.Context
                         }
                     }
                 }
+                if (config.ContainsKey("exclude"))
+                {
+                    excludes.AddRange((IEnumerable<string>)config["exclude"]);
+                }
 
                 var context = new SiteContext
                 {
@@ -193,9 +197,14 @@ namespace Pretzel.Logic.Templating.Context
             return postFirstLine != null && postFirstLine.StartsWith("---");
         }
 
+        private bool IsExcludedPath(string relativePath)
+        {
+            return excludes.Contains(relativePath) || excludes.Any(e => relativePath.StartsWith(e));
+        }
+
         public bool CanBeIncluded(string relativePath)
         {
-            if (excludes.Count > 0 && excludes.Contains(relativePath))
+            if (excludes.Count > 0 && IsExcludedPath(relativePath))
             {
                 return false;
             }

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -191,6 +191,11 @@ namespace Pretzel.Logic.Templating.Context
             return excludes.Contains(relativePath) || excludes.Any(e => relativePath.StartsWith(e));
         }
 
+        private bool IsIncludedPath(string relativePath)
+        {
+            return includes.Contains(relativePath) || includes.Any(e => relativePath.StartsWith(e));
+        }
+
         public bool CanBeIncluded(string relativePath)
         {
             if (excludes.Count > 0 && IsExcludedPath(relativePath))
@@ -198,7 +203,7 @@ namespace Pretzel.Logic.Templating.Context
                 return false;
             }
 
-            if (includes.Count > 0 && includes.Contains(relativePath))
+            if (includes.Count > 0 && IsIncludedPath(relativePath))
             {
                 return true;
             }

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -420,8 +420,7 @@ title: Title
             // arrange
             Func<string, bool> function = generator.CanBeIncluded;
             fileSystem.AddFile(@"C:\TestSite\_config.yml", new MockFileData(@"---
-pretzel:
-  include: [_folder, .something-else, some-file.tmp, test\somefile.txt, subfolder\childfolder, anotherfolder\tempfile.tmp]
+include: [_folder, .something-else, some-file.tmp, test\somefile.txt, subfolder\childfolder, anotherfolder\tempfile.tmp]
 ---"));
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
@@ -450,14 +449,14 @@ pretzel:
             // arrange
             Func<string, bool> function = generator.CanBeIncluded;
             fileSystem.AddFile(@"C:\TestSite\_config.yml", new MockFileData(@"---
-pretzel:
-  exclude: [folder, .htaccess, some-file.tmp, test\somefile.txt, subfolder\childfolder, anotherfolder\tempfile.tmp]
+exclude: [folder, .htaccess, some-file.tmp, test\somefile.txt, subfolder\childfolder, anotherfolder\tempfile.tmp]
 ---"));
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
 
             // assert
             Assert.False(function("folder"));
+            Assert.False(function("folder\file.txt"));
             Assert.False(function("_folder"));
 
             // .htaccess is excluded
@@ -480,9 +479,8 @@ pretzel:
             // arrange
             Func<string, bool> function = generator.CanBeIncluded;
             fileSystem.AddFile(@"C:\TestSite\_config.yml", new MockFileData(@"---
-pretzel:
-  include: [_folder, .something-else]
-  exclude: [folder, test\somefile.txt]
+include: [_folder, .something-else]
+exclude: [folder, test\somefile.txt]
 ---"));
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -438,6 +438,8 @@ include: [_folder, .something-else, some-file.tmp, test\somefile.txt, subfolder\
             Assert.False(function("some-file.TMP"));
             Assert.True(function("another-file.bar"));
 
+            Assert.True(function("_folder\file.txt"));
+
             Assert.True(function(@"test\somefile.txt"));
             Assert.True(function(@"subfolder\childfolder"));
             Assert.True(function(@"anotherfolder\tempfile.tmp"));


### PR DESCRIPTION
Allows the `exclude` config setting to be used as well as `pretzel > exclude` and adds support for folder excludes instead of only by full path.