### PR TITLE
Update FileContentProvider.cs

### DIFF
--- a/src/Pretzel/WebHost/FileContentProvider.cs
+++ b/src/Pretzel/WebHost/FileContentProvider.cs
@@ -127,7 +127,7 @@ namespace Pretzel
         /// <returns>Path to the file</returns>
         private string GetFullPath(string request) 
         {
-            return Uri.UnescapeDataString(Path.Combine(basePath + request));
+            return System.Web.HttpUtility.UrlDecode(Path.Combine(basePath + request));
         }
     }
 }


### PR DESCRIPTION
Use httpUtility

file:
mark van.html

Rendered with:
http://localhost:8080/mark+van.html
http://localhost:8080/mark%20van.html

fixes #125

http://blogs.msdn.com/b/yangxind/archive/2006/11/09/don-t-use-net-system-uri-unescapedatastring-in-url-decoding.aspx