### PR TITLE
category handling compliant with jekyll

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -296,10 +296,6 @@ namespace Pretzel.Logic.Templating.Context
         {
             var categories = new List<string>();
 
-            var postPath = page.File.Replace(context.SourceFolder, string.Empty);
-            string rawCategories = postPath.Replace(fileSystem.Path.GetFileName(page.File), string.Empty).Replace("_posts", string.Empty);
-            categories.AddRange(rawCategories.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries));
-
             if (header.ContainsKey("categories") && header["categories"] is IEnumerable<string>)
             {
                 categories.AddRange((IEnumerable<string>)header["categories"]);
@@ -307,6 +303,13 @@ namespace Pretzel.Logic.Templating.Context
             else if (header.ContainsKey("category"))
             {
                 categories.Add((string)header["category"]);
+            }
+
+            if (categories.Count == 0)
+            {
+                var postPath = page.File.Replace(context.SourceFolder, string.Empty);
+                string rawCategories = postPath.Replace(fileSystem.Path.GetFileName(page.File), string.Empty).Replace("_posts", string.Empty);
+                categories.AddRange(rawCategories.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries));
             }
 
             return categories;

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -1057,12 +1057,37 @@ date: 20150127
         }
 
         [Fact]
-        public void permalink_with_folder_categories()
+        public void permalink_with_folder_and_post_categories()
         {
             fileSystem.AddFile(@"C:\TestSite\foo\bar\_posts\2015-03-09-SomeFile.md", new MockFileData(@"---
 categories: [cat1, cat2]
 ---# Title"));
-            var outputPath = "/foo/bar/cat1/cat2/2015/03/09/SomeFile.html";
+            var outputPath = "/cat1/cat2/2015/03/09/SomeFile.html";
+            // act
+            var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
+            var firstPost = siteContext.Posts.First();
+            Assert.Equal(outputPath, firstPost.Url);
+        }
+
+        [Fact]
+        public void permalink_with_folder_categories()
+        {
+            fileSystem.AddFile(@"C:\TestSite\foo\bar\_posts\2015-03-09-SomeFile.md", new MockFileData(@"---
+---# Title"));
+            var outputPath = "/foo/bar/2015/03/09/SomeFile.html";
+            // act
+            var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
+            var firstPost = siteContext.Posts.First();
+            Assert.Equal(outputPath, firstPost.Url);
+        }
+
+        [Fact]
+        public void permalink_with_post_categories()
+        {
+            fileSystem.AddFile(@"C:\TestSite\_posts\2015-03-09-SomeFile.md", new MockFileData(@"---
+categories: [cat1, cat2]
+---# Title"));
+            var outputPath = "/cat1/cat2/2015/03/09/SomeFile.html";
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
             var firstPost = siteContext.Posts.First();

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -1607,7 +1607,7 @@ namespace Pretzel.Tests.Templating.Jekyll
         {
             private SiteContext Context;
             private const string ContentWithCategory = "---\r\n category: mycategory \r\n permalink: /:categories/:year/:month/:day/:title.html \r\n---\r\n{{ site.categories[0].name }}";
-            private const string ExpectedPageContent = "<p>my</p>";
+            private const string ExpectedPageContent = "<p>mycategory</p>";
 
             public override LiquidEngine Given()
             {
@@ -1628,22 +1628,20 @@ namespace Pretzel.Tests.Templating.Jekyll
             {
                 Assert.Equal(Context.Posts.Count, 1);
                 var categories = Context.Posts[0].Categories.ToList();
-                Assert.Equal(categories.Count, 3);
-                Assert.Equal(categories[0], "oh");
-                Assert.Equal(categories[1], "my");
-                Assert.Equal(categories[2], "mycategory");
+                Assert.Equal(categories.Count, 1);
+                Assert.Equal(categories[0], "mycategory");
             }
 
             [Fact]
             public void The_permalink_should_use_all_categories()
             {
-                Assert.True(FileSystem.File.Exists(@"C:\website\_site\oh\my\mycategory\2015\02\02\post.html"));
+                Assert.True(FileSystem.File.Exists(@"C:\website\_site\mycategory\2015\02\02\post.html"));
             }
 
             [Fact]
             public void The_first_alphabetically_category_must_appear_in_the_content()
             {
-                Assert.Equal(ExpectedPageContent, FileSystem.File.ReadAllText(@"C:\website\_site\oh\my\mycategory\2015\02\02\post.html").RemoveWhiteSpace());
+                Assert.Equal(ExpectedPageContent, FileSystem.File.ReadAllText(@"C:\website\_site\mycategory\2015\02\02\post.html").RemoveWhiteSpace());
             }
         }
 


### PR DESCRIPTION
Only if the page's front matter doesn't specify categories, extract them from the path. See #247 for reasoning.