### PR TITLE
Inconsistent page.date handling

### DIFF
--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -270,11 +270,8 @@ namespace Pretzel.Logic.Templating.Context
                 // resolve id
                 page.Id = page.Url.Replace(".html", string.Empty).Replace("index", string.Empty);
 
-                // ensure the date is accessible in the hash
-                if (!page.Bag.ContainsKey("date"))
-                {
-                    page.Bag["date"] = page.Date;
-                }
+                // always write date back to Bag as DateTime
+                page.Bag["date"] = page.Date;
 
                 // The GetDirectoryPage method is reentrant, we need a cache to stop a stack overflow :)
                 pageCache.Add(file, page);

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -718,20 +718,20 @@ param: value
         [Fact]
         public void page_metadata_values()
         {
-            var currentDate = new DateTime(2015, 1, 27).ToShortDateString();
+            var currentDate = new DateTime(2015, 1, 27);
             fileSystem.AddFile(@"C:\TestSite\SomeFile.md", new MockFileData(string.Format(@"---
 title: my title
 date: {0}
 param: value
 ---# Title",
-            currentDate)));
+            currentDate.ToShortDateString())));
 
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
 
             Assert.Equal(1, siteContext.Pages.Count);
             Assert.Equal("my title", siteContext.Pages[0].Title);
-            Assert.Equal(new DateTime(2015, 1, 27), siteContext.Pages[0].Date);
+            Assert.Equal(currentDate, siteContext.Pages[0].Date);
             Assert.Equal("<h1>Title</h1>", siteContext.Pages[0].Content.RemoveWhiteSpace());
             Assert.Equal(@"C:\TestSite\_site\SomeFile.md", siteContext.Pages[0].Filepath);
             Assert.Equal(@"C:\TestSite\SomeFile.md", siteContext.Pages[0].File);
@@ -811,20 +811,20 @@ param: value
         [Fact]
         public void post_metadata_values()
         {
-            var currentDate = new DateTime(2015, 1, 27).ToShortDateString();
+            var currentDate = new DateTime(2015, 1, 27);
             fileSystem.AddFile(@"C:\TestSite\_posts\SomeFile.md", new MockFileData(string.Format(@"---
 title: my title
 date: {0}
 param: value
 ---# Title",
-            currentDate)));
+            currentDate.ToShortDateString())));
 
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
 
             Assert.Equal(1, siteContext.Posts.Count);
             Assert.Equal("my title", siteContext.Posts[0].Title);
-            Assert.Equal(new DateTime(2015, 1, 27), siteContext.Posts[0].Date);
+            Assert.Equal(currentDate, siteContext.Posts[0].Date);
             Assert.Equal("<h1>Title</h1>", siteContext.Posts[0].Content.RemoveWhiteSpace());
             Assert.Equal(@"C:\TestSite\_site\SomeFile.md", siteContext.Posts[0].Filepath);
             Assert.Equal(@"C:\TestSite\_posts\SomeFile.md", siteContext.Posts[0].File);

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -1898,7 +1898,7 @@ categories: [{0}]
 
         public class Given_Page_Without_Explicit_Date : BakingEnvironment<LiquidEngine> {
             private const string PageContents = "---\r\n layout: nil \r\n---\r\n\r\n{{ page.date | date_to_xmlschema }}";
-            private const string ExpectedfileContents = "<p>2015-02-22T00:00:00+01:00</p>";
+            private readonly string ExpectedfileContents = new DateTime(2015, 2, 22).ToString("<p>yyyy-MM-ddTHH:mm:sszzz<\\/p>");
 
             public override LiquidEngine Given() {
                 var engine = new LiquidEngine();
@@ -1921,8 +1921,8 @@ categories: [{0}]
         }
 
         public class Given_Page_With_Explicit_Date : BakingEnvironment<LiquidEngine> {
-            private const string PageContents = "---\r\n layout: nil \r\n date: 2015-02-23 12:00:00\r\n---\r\n\r\n{{ page.date | date_to_xmlschema }}";
-            private const string ExpectedfileContents = "<p>2015-02-23T12:00:00+01:00</p>";
+            private const string PageContents = "---\r\n layout: nil \r\n date: 2015-02-23 12:30:00\r\n---\r\n\r\n{{ page.date | date_to_xmlschema }}";
+            private readonly string ExpectedfileContents = new DateTime(2015, 2, 23, 12, 30, 0).ToString("<p>yyyy-MM-ddTHH:mm:sszzz<\\/p>");
 
             public override LiquidEngine Given() {
                 var engine = new LiquidEngine();

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -1895,5 +1895,53 @@ categories: [{0}]
             // act
             Assert.Equal(ExpectedfileContents, fileSystem.File.ReadAllText(string.Format(@"C:\TestSite\_site\{0}", expectedUrl)).RemoveWhiteSpace());
         }
+
+        public class Given_Page_Without_Explicit_Date : BakingEnvironment<LiquidEngine> {
+            private const string PageContents = "---\r\n layout: nil \r\n---\r\n\r\n{{ page.date | date_to_xmlschema }}";
+            private const string ExpectedfileContents = "<p>2015-02-22T00:00:00+01:00</p>";
+
+            public override LiquidEngine Given() {
+                var engine = new LiquidEngine();
+                engine.Initialize();
+                return engine;
+            }
+
+            public override void When() {
+                FileSystem.AddFile(@"C:\website\_posts\2015-02-22-post.md", new MockFileData(PageContents));
+                var generator = GetSiteContextGenerator(FileSystem);
+                var context = generator.BuildContext(@"C:\website\", @"D:\Result\_site", false);
+                Subject.FileSystem = FileSystem;
+                Subject.Process(context);
+            }
+
+            [Fact]
+            public void The_File_Should_Display_The_Page_Url() {
+                Assert.Equal(ExpectedfileContents, FileSystem.File.ReadAllText(@"D:\Result\_site\2015\02\22\post.html").RemoveWhiteSpace());
+            }
+        }
+
+        public class Given_Page_With_Explicit_Date : BakingEnvironment<LiquidEngine> {
+            private const string PageContents = "---\r\n layout: nil \r\n date: 2015-02-23 12:00:00\r\n---\r\n\r\n{{ page.date | date_to_xmlschema }}";
+            private const string ExpectedfileContents = "<p>2015-02-23T12:00:00+01:00</p>";
+
+            public override LiquidEngine Given() {
+                var engine = new LiquidEngine();
+                engine.Initialize();
+                return engine;
+            }
+
+            public override void When() {
+                FileSystem.AddFile(@"C:\website\_posts\2015-02-22-post.md", new MockFileData(PageContents));
+                var generator = GetSiteContextGenerator(FileSystem);
+                var context = generator.BuildContext(@"C:\website\", @"D:\Result\_site", false);
+                Subject.FileSystem = FileSystem;
+                Subject.Process(context);
+            }
+
+            [Fact]
+            public void The_File_Should_Display_The_Page_Url() {
+                Assert.Equal(ExpectedfileContents, FileSystem.File.ReadAllText(@"D:\Result\_site\2015\02\23\post.html").RemoveWhiteSpace());
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently the handling of `page.date` is inconsistent:

1. If there's no date specified in a page's front-matter but is extracted from the filename, `page.Bag["date"]` is a `DateTime`
2. If there's a date specified in a page's front-matter, `page.Bag["date"]` is a `string` (as parsed by YamlDotNet)

When you're using `{{ page.date | date_to_xmlschema }}` on your template, and `page.Bag["date"]` is a `string`, it will be rendered as `Liquid error: Object of type 'System.String' cannot be converted to type 'System.DateTime'.`

This PR fixes this by always adding the date back to `page.Bag["date"]` as `DateTime` (in fact I only had to delete some code in `SiteContextGenerator.cs`. :wink:) Two other tests relied on strings, which I fixed.