### PR TITLE
Fix pagination when paginate_link points to a directory

### DIFF
--- a/src/Pretzel.Logic/Templating/JekyllEngineBase.cs
+++ b/src/Pretzel.Logic/Templating/JekyllEngineBase.cs
@@ -122,6 +122,9 @@ namespace Pretzel.Logic.Templating
                     prevLink = link;
 
                     var path = Path.Combine(outputDirectory, link.ToRelativeFile());
+                    if (path.EndsWith(FileSystem.Path.DirectorySeparatorChar.ToString())) {
+                        path = Path.Combine(path, "index.html");
+                    }
                     pageContexts.Add(new PageContext(pageContext) { Paginator = newPaginator, OutputPath = path });
                 }
             }

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -292,7 +292,7 @@ namespace Pretzel.Tests.Templating.Jekyll
         {
             private const string TemplateContents = "<html><head><title>{{ page.title }}</title></head><body>{{ content }}</body></html>";
             private const string PostContents = "---\r\n layout: default \r\n title: 'Post'\r\n---\r\n\r\n## Hello World!";
-            private const string IndexContents = "---\r\n layout: default \r\n paginate: 2 \r\n paginate_link: /blog/page:page/index.html \r\n title: 'A different title'\r\n---\r\n\r\n## Hello World!";
+            private const string IndexContents = "---\r\n layout: default \r\n paginate: 2 \r\n paginate_link: /blog/page:page/ \r\n title: 'A different title'\r\n---\r\n\r\n## Hello World!";
             private const string ExpectedfileContents = "<html><head><title>A different title</title></head><body><h2>Hello World!</h2></body></html>";
 
             public override LiquidEngine Given()


### PR DESCRIPTION
permalink can point to a directory, and Pretzel knows it must create an index.html in that directory.
This patch add support for this behavior when pagination is used.
Modified custom pagination link tests to test this case.

fixes #254 