### PR TITLE
Changed date guessing heuristic to use last modification time of posts instead of current time, if no better data is available.

### DIFF
--- a/src/Pretzel.Logic/Extensions/StringExtensions.cs
+++ b/src/Pretzel.Logic/Extensions/StringExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 
 namespace Pretzel.Logic.Extensions
@@ -543,18 +545,20 @@ namespace Pretzel.Logic.Extensions
             return false;
         }
 
-        public static DateTime Datestamp(this string file)
+        public static DateTime Datestamp(this string file, IFileSystem fs)
         {
-            var fileName = file.Substring(file.LastIndexOf("\\"));
+            var fileName = fs.Path.GetFileName(file);
             var tokens = fileName.Split('-');
 
-            if (tokens.Length < 3)
-                return DateTime.Now;
+            if (tokens.Length < 3) 
+            {
+                return  fs.FileInfo.FromFileName(file).LastWriteTime;
+            }
 
-            var timestampText = string.Join("-", tokens.Take(3)).Trim('\\');
+            var timestampText = string.Join("-", tokens.Take(3)).Trim(fs.Path.DirectorySeparatorChar);
 
             DateTime timestamp;
-            return DateTime.TryParse(timestampText, out timestamp) ? timestamp : DateTime.Now;
+            return DateTime.TryParse(timestampText, out timestamp) ? timestamp : fs.FileInfo.FromFileName(file).LastWriteTime;
         }
 
         public static string ToUnderscoreCase(this string str)

--- a/src/Pretzel.Logic/Pretzel.Logic.csproj
+++ b/src/Pretzel.Logic/Pretzel.Logic.csproj
@@ -66,9 +66,9 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.104, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.116, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.104\lib\net40\System.IO.Abstractions.dll</HintPath>
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.116\lib\net40\System.IO.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -237,7 +237,7 @@ namespace Pretzel.Logic.Templating.Context
                 var page = new Page
                                 {
                                     Title = header.ContainsKey("title") ? header["title"].ToString() : "this is a post",
-                                    Date = header.ContainsKey("date") ? DateTime.Parse(header["date"].ToString()) : file.Datestamp(),
+                                    Date = header.ContainsKey("date") ? DateTime.Parse(header["date"].ToString()) : file.Datestamp(fileSystem),
                                     Content = content,
                                     Filepath = isPost ? GetPathWithTimestamp(context.OutputFolder, file) : GetFilePathForPage(context, file),
                                     File = file,

--- a/src/Pretzel.Logic/packages.config
+++ b/src/Pretzel.Logic/packages.config
@@ -8,6 +8,6 @@
   <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />
   <package id="NDesk.Options" version="0.2.1" />
   <package id="RazorEngine" version="3.6.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.104" targetFramework="net40" />
+  <package id="System.IO.Abstractions" version="2.0.0.116" targetFramework="net45" />
   <package id="YamlDotNet" version="3.5.1" targetFramework="net40" />
 </packages>

--- a/src/Pretzel.Tests/Pretzel.Tests.csproj
+++ b/src/Pretzel.Tests/Pretzel.Tests.csproj
@@ -55,13 +55,13 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.104, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.116, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.104\lib\net40\System.IO.Abstractions.dll</HintPath>
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.116\lib\net40\System.IO.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.104, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.116, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.104\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.116\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -807,7 +807,7 @@ param: value
         [Fact]
         public void post_default_values()
         {
-            var filename = @"C:\TestSite\SomeFile.md";
+            var filename = @"C:\TestSite\_posts\SomeFile.md";
             var file = new MockFileData(@"---
 param: value
 ---# Title");
@@ -818,14 +818,14 @@ param: value
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
 
-            Assert.Equal(1, siteContext.Pages.Count);
-            Assert.Equal("this is a post", siteContext.Pages[0].Title);
-            Assert.Equal(lastmod, siteContext.Pages[0].Date.Date);
-            Assert.Equal("<h1>Title</h1>", siteContext.Pages[0].Content.RemoveWhiteSpace());
-            Assert.Equal(@"C:\TestSite\_site\SomeFile.md", siteContext.Pages[0].Filepath);
-            Assert.Equal(@"C:\TestSite\SomeFile.md", siteContext.Pages[0].File);
-            Assert.Equal(2, siteContext.Pages[0].Bag.Count); // param, date
-            Assert.Equal("value", siteContext.Pages[0].Bag["param"]);
+            Assert.Equal(1, siteContext.Posts.Count);
+            Assert.Equal("this is a post", siteContext.Posts[0].Title);
+            Assert.Equal(lastmod, siteContext.Posts[0].Date.Date);
+            Assert.Equal("<h1>Title</h1>", siteContext.Posts[0].Content.RemoveWhiteSpace());
+            Assert.Equal(@"C:\TestSite\_site\SomeFile.md", siteContext.Posts[0].Filepath);
+            Assert.Equal(@"C:\TestSite\_posts\SomeFile.md", siteContext.Posts[0].File);
+            Assert.Equal(2, siteContext.Posts[0].Bag.Count); // param, date
+            Assert.Equal("value", siteContext.Posts[0].Bag["param"]);
         }
 
         [Fact]

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -787,8 +787,8 @@ namespace Pretzel.Tests.Templating.Jekyll
 
             public override void When()
             {
-                FileSystem.AddFile(@"C:\website\_site\BadFormat.md", new MockFileData(OriginalPageContents) { LastWriteTime = new DateTime(2010, 01, 2) });
-                FileSystem.AddFile(@"C:\website\BadFormat.md", new MockFileData(PageContents) { LastWriteTime = new DateTime(2010, 01, 3) });
+                FileSystem.AddFile(@"C:\website\_site\BadFormat.md", new MockFileData(OriginalPageContents) { LastWriteTime = new DateTime(2013, 01, 2) });
+                FileSystem.AddFile(@"C:\website\BadFormat.md", new MockFileData(PageContents) { LastWriteTime = new DateTime(2014, 01, 3) });
 
                 var generator = GetSiteContextGenerator(FileSystem);
                 var context = generator.BuildContext(@"C:\website\", @"C:\website\_site", false);
@@ -815,7 +815,7 @@ namespace Pretzel.Tests.Templating.Jekyll
 
             public override void When()
             {
-                FileSystem.AddFile(@"C:\website\_site\BadFormat.md", new MockFileData(OriginalPageContents) { LastWriteTime = new DateTime(2010, 01, 5) });
+                FileSystem.AddFile(@"C:\website\_site\BadFormat.md", new MockFileData(OriginalPageContents) { LastWriteTime = new DateTime(2011, 01, 5) });
                 FileSystem.AddFile(@"C:\website\BadFormat.md", new MockFileData(PageContents) { LastWriteTime = new DateTime(2010, 01, 3) });
 
                 var generator = GetSiteContextGenerator(FileSystem);

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -787,8 +787,8 @@ namespace Pretzel.Tests.Templating.Jekyll
 
             public override void When()
             {
-                FileSystem.AddFile(@"C:\website\_site\BadFormat.md", new MockFileData(OriginalPageContents) { LastWriteTime = new DateTime(2013, 01, 2) });
-                FileSystem.AddFile(@"C:\website\BadFormat.md", new MockFileData(PageContents) { LastWriteTime = new DateTime(2014, 01, 3) });
+                FileSystem.AddFile(@"C:\website\_site\BadFormat.md", new MockFileData(OriginalPageContents) { LastWriteTime = new DateTime(2010, 01, 2) });
+                FileSystem.AddFile(@"C:\website\BadFormat.md", new MockFileData(PageContents) { LastWriteTime = new DateTime(2010, 01, 3) });
 
                 var generator = GetSiteContextGenerator(FileSystem);
                 var context = generator.BuildContext(@"C:\website\", @"C:\website\_site", false);

--- a/src/Pretzel.Tests/app.config
+++ b/src/Pretzel.Tests/app.config
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Abstractions" publicKeyToken="d480b5b72fb413da" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.104" newVersion="2.0.0.104"/>
+        <assemblyIdentity name="System.IO.Abstractions" publicKeyToken="d480b5b72fb413da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.116" newVersion="2.0.0.116" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/src/Pretzel.Tests/packages.config
+++ b/src/Pretzel.Tests/packages.config
@@ -4,8 +4,8 @@
   <package id="DotLiquid" version="1.8.0" targetFramework="net45" />
   <package id="NDesk.Options" version="0.2.1" />
   <package id="NSubstitute" version="1.8.1.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.104" targetFramework="net40" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.104" targetFramework="net40" />
+  <package id="System.IO.Abstractions" version="2.0.0.116" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.116" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
   <package id="xunit.runner.visualstudio" version="2.0.0-rc1-build1030" targetFramework="net40" />

--- a/src/Pretzel/Pretzel.csproj
+++ b/src/Pretzel/Pretzel.csproj
@@ -61,7 +61,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Abstractions">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.104\lib\net40\System.IO.Abstractions.dll</HintPath>
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.116\lib\net40\System.IO.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor">
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>

--- a/src/Pretzel/packages.config
+++ b/src/Pretzel/packages.config
@@ -10,7 +10,7 @@
   <package id="Owin.Builder" version="0.8.5" targetFramework="net40" />
   <package id="Owin.Extensions.Sources" version="0.8.5" targetFramework="net40" />
   <package id="Owin.Types.Sources" version="0.8.5" targetFramework="net40" />
-  <package id="System.IO.Abstractions" version="2.0.0.104" targetFramework="net40" />
+  <package id="System.IO.Abstractions" version="2.0.0.116" targetFramework="net45" />
   <package id="TaskHelpers.Sources" version="0.3" targetFramework="net40" />
   <package id="YamlDotNet" version="3.5.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Changed date guessing heuristic to use last modification time of posts instead of current time, if no better data is available.

This is a viable and better replacement as all filesystems track this, and git and other version control tools also keep track of this and set it on files on checkout.

The changes:

 - Instead of DateTime.Now the source file's LastWriteTime is used now
 - The tests were updated
 - Updated System.IO.Abstractions and TestingHelpers to version 2.0.0.116
   to avoid a bug in the System.IO.Abstractions.TestingHelpers library
   making tests to fail
   (see: https://github.com/tathamoddie/System.IO.Abstractions/issues/122 )