### PR TITLE
Added missing next and previous items in the page Hash in the Liquid engine

### DIFF
--- a/src/Pretzel.Logic/Templating/Jekyll/LiquidEngine.cs
+++ b/src/Pretzel.Logic/Templating/Jekyll/LiquidEngine.cs
@@ -62,6 +62,9 @@ namespace Pretzel.Logic.Templating.Jekyll
                 y.Add("title", Context.Title);
             }
 
+            y.Add("previous", pageContext.Previous);
+            y.Add("next", pageContext.Next);
+
             var x = Hash.FromAnonymousObject(new
             {
                 site = contextDrop.ToHash(),

--- a/src/Pretzel.Logic/Templating/JekyllEngineBase.cs
+++ b/src/Pretzel.Logic/Templating/JekyllEngineBase.cs
@@ -58,12 +58,12 @@ namespace Pretzel.Logic.Templating
             }
         }
 
-        private static Page GetNext(IList<Page> pages, int index)
+        private static Page GetPrevious(IList<Page> pages, int index)
         {
             return index < pages.Count - 1 ? pages[index + 1] : null;
         }
 
-        private static Page GetPrevious(IList<Page> pages, int index)
+        private static Page GetNext(IList<Page> pages, int index)
         {
             return index >= 1 ? pages[index - 1] : null;
         }

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -1863,7 +1863,7 @@ namespace Pretzel.Tests.Templating.Jekyll
         public class Given_Page_Has_Page_Previous_Url : BakingEnvironment<LiquidEngine>
         {
             private const string PageContents = "---\r\n layout: nil \r\n---\r\n\r\n{{ page.previous.url }}";
-            private const string ExpectedfileContents = "<p>/2015/03/22/previouspost.html</p>";
+            private const string ExpectedfileContents = "<p>/2015/01/22/previouspost.html</p>";
 
             public override LiquidEngine Given()
             {
@@ -1875,7 +1875,7 @@ namespace Pretzel.Tests.Templating.Jekyll
             public override void When()
             {
                 FileSystem.AddFile(@"C:\website\_posts\2015-02-22-post.md", new MockFileData(PageContents));
-                FileSystem.AddFile(@"C:\website\_posts\2015-03-22-previouspost.md", new MockFileData("---\r\n layout: nil \r\n---\r\n\r\n"));
+                FileSystem.AddFile(@"C:\website\_posts\2015-01-22-previouspost.md", new MockFileData("---\r\n layout: nil \r\n---\r\n\r\n"));
                 var generator = GetSiteContextGenerator(FileSystem);
                 var context = generator.BuildContext(@"C:\website\", @"D:\Result\_site", false);
                 Subject.FileSystem = FileSystem;
@@ -1883,7 +1883,7 @@ namespace Pretzel.Tests.Templating.Jekyll
             }
 
             [Fact]
-            public void The_File_Should_Display_The_Page_Url()
+            public void The_File_Should_Display_The_Previous_Page_Url()
             {
                 Assert.Equal(ExpectedfileContents, FileSystem.File.ReadAllText(@"D:\Result\_site\2015\02\22\post.html").RemoveWhiteSpace());
             }
@@ -1892,7 +1892,7 @@ namespace Pretzel.Tests.Templating.Jekyll
         public class Given_Page_Has_Page_Next_Url : BakingEnvironment<LiquidEngine>
         {
             private const string PageContents = "---\r\n layout: nil \r\n---\r\n\r\n{{ page.next.url }}";
-            private const string ExpectedfileContents = "<p>/2015/01/22/nextpost.html</p>";
+            private const string ExpectedfileContents = "<p>/2015/03/22/nextpost.html</p>";
 
             public override LiquidEngine Given()
             {
@@ -1904,7 +1904,7 @@ namespace Pretzel.Tests.Templating.Jekyll
             public override void When()
             {
                 FileSystem.AddFile(@"C:\website\_posts\2015-02-22-post.md", new MockFileData(PageContents));
-                FileSystem.AddFile(@"C:\website\_posts\2015-01-22-nextpost.md", new MockFileData("---\r\n layout: nil \r\n---\r\n\r\n"));
+                FileSystem.AddFile(@"C:\website\_posts\2015-03-22-nextpost.md", new MockFileData("---\r\n layout: nil \r\n---\r\n\r\n"));
                 var generator = GetSiteContextGenerator(FileSystem);
                 var context = generator.BuildContext(@"C:\website\", @"D:\Result\_site", false);
                 Subject.FileSystem = FileSystem;
@@ -1912,7 +1912,7 @@ namespace Pretzel.Tests.Templating.Jekyll
             }
 
             [Fact]
-            public void The_File_Should_Display_The_Page_Url()
+            public void The_File_Should_Display_The_Next_Page_Url()
             {
                 Assert.Equal(ExpectedfileContents, FileSystem.File.ReadAllText(@"D:\Result\_site\2015\02\22\post.html").RemoveWhiteSpace());
             }

--- a/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
+++ b/src/Pretzel.Tests/Templating/Jekyll/LiquidEngineTests.cs
@@ -1860,6 +1860,64 @@ namespace Pretzel.Tests.Templating.Jekyll
             }
         }
 
+        public class Given_Page_Has_Page_Previous_Url : BakingEnvironment<LiquidEngine>
+        {
+            private const string PageContents = "---\r\n layout: nil \r\n---\r\n\r\n{{ page.previous.url }}";
+            private const string ExpectedfileContents = "<p>/2015/03/22/previouspost.html</p>";
+
+            public override LiquidEngine Given()
+            {
+                var engine = new LiquidEngine();
+                engine.Initialize();
+                return engine;
+            }
+
+            public override void When()
+            {
+                FileSystem.AddFile(@"C:\website\_posts\2015-02-22-post.md", new MockFileData(PageContents));
+                FileSystem.AddFile(@"C:\website\_posts\2015-03-22-previouspost.md", new MockFileData("---\r\n layout: nil \r\n---\r\n\r\n"));
+                var generator = GetSiteContextGenerator(FileSystem);
+                var context = generator.BuildContext(@"C:\website\", @"D:\Result\_site", false);
+                Subject.FileSystem = FileSystem;
+                Subject.Process(context);
+            }
+
+            [Fact]
+            public void The_File_Should_Display_The_Page_Url()
+            {
+                Assert.Equal(ExpectedfileContents, FileSystem.File.ReadAllText(@"D:\Result\_site\2015\02\22\post.html").RemoveWhiteSpace());
+            }
+        }
+
+        public class Given_Page_Has_Page_Next_Url : BakingEnvironment<LiquidEngine>
+        {
+            private const string PageContents = "---\r\n layout: nil \r\n---\r\n\r\n{{ page.next.url }}";
+            private const string ExpectedfileContents = "<p>/2015/01/22/nextpost.html</p>";
+
+            public override LiquidEngine Given()
+            {
+                var engine = new LiquidEngine();
+                engine.Initialize();
+                return engine;
+            }
+
+            public override void When()
+            {
+                FileSystem.AddFile(@"C:\website\_posts\2015-02-22-post.md", new MockFileData(PageContents));
+                FileSystem.AddFile(@"C:\website\_posts\2015-01-22-nextpost.md", new MockFileData("---\r\n layout: nil \r\n---\r\n\r\n"));
+                var generator = GetSiteContextGenerator(FileSystem);
+                var context = generator.BuildContext(@"C:\website\", @"D:\Result\_site", false);
+                Subject.FileSystem = FileSystem;
+                Subject.Process(context);
+            }
+
+            [Fact]
+            public void The_File_Should_Display_The_Page_Url()
+            {
+                Assert.Equal(ExpectedfileContents, FileSystem.File.ReadAllText(@"D:\Result\_site\2015\02\22\post.html").RemoveWhiteSpace());
+            }
+        }
+
         [InlineData("date", @"cat1\cat2\2015\03\09\foobar-baz.html", "cat1,cat2")]
         [InlineData("date", @"2015\03\09\foobar-baz.html", "")]
         [InlineData("/:dashcategories/:year/:month/:day/:title.html", @"cat1-cat2\2015\03\09\foobar-baz.html", "cat1,cat2")]


### PR DESCRIPTION
While browsing the files generated by `pretzel create` I noticed that, after adding a new post, there were no previous and next link at the bottom of the page while the layout contained them.

This small change made those links appeared in the demo site from `pretzel create` when multiple posts are present.

I don't know if it is the right place for the change, and I didn't make tests since the Razor counterpart, which already worked, does not seem to have any.