### PR TITLE
added option only_frontmatter_categories

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -30,6 +30,7 @@ All existing plugins must be recompiled with referencing only Pretzel.Logic.
 - [#253](https://github.com/Code52/pretzel/pull/253) - Run on Mono contributed by Thiago 'Jedi' Abreu ([thiagoabreu](https://github.com/thiagoabreu))
 - [#259](https://github.com/Code52/pretzel/pull/259) - Changed date guessing heuristic to use last modification time of posts instead of current time, if no better data is available. contributed by Gábor Gergely ([kodfodrasz](https://github.com/kodfodrasz))
 - [#260](https://github.com/Code52/pretzel/pull/260) - Refactor logging contributed by Gábor Gergely ([kodfodrasz](https://github.com/kodfodrasz))
+- [#274](https://github.com/Code52/pretzel/pull/274) - Added option to only use categories found in posts's frontmatter by Thomas Freudenberg ([thoemmi](https://github.com/thoemmi))
 
 ## Fixes
 - [#198](https://github.com/Code52/pretzel/issues/198) - Liquid tag/filter with underscore doesn't works in markdown files

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -290,10 +290,12 @@ namespace Pretzel.Logic.Templating.Context
         {
             var categories = new List<string>();
 
-            var postPath = page.File.Replace(context.SourceFolder, string.Empty);
-            string rawCategories = postPath.Replace(fileSystem.Path.GetFileName(page.File), string.Empty).Replace("_posts", string.Empty);
-            categories.AddRange(rawCategories.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries));
-
+            if (!IsOnlyFrontmatterCategories(context))
+            {
+                var postPath = page.File.Replace(context.SourceFolder, string.Empty);
+                string rawCategories = postPath.Replace(fileSystem.Path.GetFileName(page.File), string.Empty).Replace("_posts", string.Empty);
+                categories.AddRange(rawCategories.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries));
+            }
             if (header.ContainsKey("categories") && header["categories"] is IEnumerable<string>)
             {
                 categories.AddRange((IEnumerable<string>)header["categories"]);
@@ -304,6 +306,16 @@ namespace Pretzel.Logic.Templating.Context
             }
 
             return categories;
+        }
+
+        private static bool IsOnlyFrontmatterCategories(SiteContext context)
+        {
+            object onlyFrontmatterCategories;
+            if (!context.Config.TryGetValue("only_frontmatter_categories", out onlyFrontmatterCategories))
+            {
+                return false;
+            }
+            return onlyFrontmatterCategories is bool && (bool) onlyFrontmatterCategories;
         }
 
         private string GetFilePathForPage(SiteContext context, string file)

--- a/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
+++ b/src/Pretzel.Tests/Templating/Context/SiteContextGeneratorTests.cs
@@ -40,7 +40,7 @@ namespace Pretzel.Tests.Templating.Context
             // assert
             Assert.Equal(1, siteContext.Posts.Count);
         }
-        
+
         [Fact]
         public void posts_do_not_include_pages()
         {
@@ -991,6 +991,20 @@ date: 20150127
 categories: [cat1, cat2]
 ---# Title"));
             var outputPath = "/foo/bar/cat1/cat2/2015/03/09/SomeFile.html";
+            // act
+            var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
+            var firstPost = siteContext.Posts.First();
+            Assert.Equal(outputPath, firstPost.Url);
+        }
+
+        [Fact]
+        public void permalink_with_folder_categories_frontmatter_only()
+        {
+            fileSystem.AddFile(@"C:\TestSite\_config.yml", new MockFileData(@"only_frontmatter_categories: true"));
+            fileSystem.AddFile(@"C:\TestSite\foo\bar\_posts\2015-03-09-SomeFile.md", new MockFileData(@"---
+categories: [cat1, cat2]
+---# Title"));
+            var outputPath = "/cat1/cat2/2015/03/09/SomeFile.html";
             // act
             var siteContext = generator.BuildContext(@"C:\TestSite", @"C:\TestSite\_site", false);
             var firstPost = siteContext.Posts.First();


### PR DESCRIPTION
As described in #247 I added an option `only_frontmatter_categories` to `_config.yml`. If that option is set to `true`, `post.Categories` only contains categories found in its frontmatter, but none extracted from the post's path.