### PR TITLE
allow System.IO.Abstractions in ScriptCs

### DIFF
--- a/src/Pretzel/Program.cs
+++ b/src/Pretzel/Program.cs
@@ -133,14 +133,15 @@ namespace Pretzel
                         var scriptCsCatalogMethod = factoryType.GetMethod("CreateScriptCsCatalog");
                         if (scriptCsCatalogMethod != null)
                         {
-                            var catalog = (ComposablePartCatalog)scriptCsCatalogMethod.Invoke(null, new object[] 
+                            var catalog = (ComposablePartCatalog)scriptCsCatalogMethod.Invoke(null, new object[]
                                 {
                                     pluginsPath,
-                                    new[] 
+                                    new[]
                                     {
                                         typeof(DotLiquid.Tag),
                                         typeof(Logic.Extensibility.ITag),
-                                        typeof(Logic.Templating.Context.SiteContext)
+                                        typeof(Logic.Templating.Context.SiteContext),
+                                        typeof(IFileSystem),
                                     }
                                 });
                             mainCatalog.Catalogs.Add(catalog);


### PR DESCRIPTION
I tried to use `IFileSystem` in ScriptCs, but it couldn't find the type.

I added `#r System.IO.Abstractions` to the top of my script, but the script engine tried to load that assembly from the GAC instead of the local folder (I assume the engine has some special handling of files starting with `System.`).

Therefore I added `IFileSystem` to the preloaded types. With this change you can use `IFileSystem` in your ScriptCs plugins.