### PR TITLE
[RFC] new extension point `IBeforeProcessingTransform`

### DIFF
--- a/src/Pretzel.Logic/Configuration.cs
+++ b/src/Pretzel.Logic/Configuration.cs
@@ -1,4 +1,5 @@
-﻿using Pretzel.Logic.Extensions;
+﻿using System;
+using Pretzel.Logic.Extensions;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 
@@ -15,7 +16,7 @@ namespace Pretzel.Logic
         IDictionary<string, object> ToDictionary();
     }
 
-    internal sealed class Configuration : IConfiguration
+    public sealed class Configuration : IConfiguration
     {
         private const string ConfigFileName = "_config.yml";
 
@@ -31,13 +32,13 @@ namespace Pretzel.Logic
             }
         }
 
-        internal Configuration()
+        public Configuration()
         {
-            _config = new Dictionary<string, object>();
+            _config = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             CheckDefaultConfig();
         }
 
-        internal Configuration(IFileSystem fileSystem, string sitePath)
+        public Configuration(IFileSystem fileSystem, string sitePath)
             : this()
         {
             _fileSystem = fileSystem;

--- a/src/Pretzel.Logic/Configuration.cs
+++ b/src/Pretzel.Logic/Configuration.cs
@@ -15,7 +15,7 @@ namespace Pretzel.Logic
         IDictionary<string, object> ToDictionary();
     }
 
-    public sealed class Configuration : IConfiguration
+    internal sealed class Configuration : IConfiguration
     {
         private const string ConfigFileName = "_config.yml";
 
@@ -31,13 +31,13 @@ namespace Pretzel.Logic
             }
         }
 
-        public Configuration()
+        internal Configuration()
         {
             _config = new Dictionary<string, object>();
             CheckDefaultConfig();
         }
 
-        public Configuration(IFileSystem fileSystem, string sitePath)
+        internal Configuration(IFileSystem fileSystem, string sitePath)
             : this()
         {
             _fileSystem = fileSystem;

--- a/src/Pretzel.Logic/Configuration.cs
+++ b/src/Pretzel.Logic/Configuration.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Pretzel.Logic.Extensions;
+﻿using Pretzel.Logic.Extensions;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 
@@ -34,7 +33,7 @@ namespace Pretzel.Logic
 
         public Configuration()
         {
-            _config = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            _config = new Dictionary<string, object>();
             CheckDefaultConfig();
         }
 

--- a/src/Pretzel.Logic/Extensibility/IBeforeProcessingTransform.cs
+++ b/src/Pretzel.Logic/Extensibility/IBeforeProcessingTransform.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel.Composition;
+using Pretzel.Logic.Templating.Context;
+
+namespace Pretzel.Logic.Extensibility {
+    [InheritedExport]
+    public interface IBeforeProcessingTransform {
+        void Transform(SiteContext context);
+    }
+}

--- a/src/Pretzel.Logic/Pretzel.Logic.csproj
+++ b/src/Pretzel.Logic/Pretzel.Logic.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Extensibility\IFilter.cs" />
     <Compile Include="Extensibility\ILightweightMarkupEngine.cs" />
     <Compile Include="Extensibility\IName.cs" />
+    <Compile Include="Extensibility\IBeforeProcessingTransform.cs" />
     <Compile Include="Extensibility\ITag.cs" />
     <Compile Include="Extensibility\TagFactoryBase.cs" />
     <Compile Include="Extensions\IAssembly.cs" />

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
+using Pretzel.Logic.Extensibility;
 
 namespace Pretzel.Logic.Templating.Context
 {
@@ -20,6 +21,9 @@ namespace Pretzel.Logic.Templating.Context
         private readonly List<string> excludes = new List<string>();
         private readonly LinkHelper linkHelper;
         private readonly IConfiguration _config;
+
+        [ImportMany]
+        public IEnumerable<IBeforeProcessingTransform> BeforeProcessingTransforms;
 
         [ImportingConstructor]
         public SiteContextGenerator(IFileSystem fileSystem, LinkHelper linkHelper, IConfiguration config)
@@ -57,6 +61,14 @@ namespace Pretzel.Logic.Templating.Context
                 BuildTagsAndCategories(context);
 
                 context.Pages = BuildPages(_config, context).ToList();
+
+                if (BeforeProcessingTransforms != null)
+                {
+                    foreach (var pageTransform in BeforeProcessingTransforms)
+                    {
+                        pageTransform.Transform(context);
+                    }
+                }
 
                 return context;
             }

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -64,9 +64,9 @@ namespace Pretzel.Logic.Templating.Context
 
                 if (BeforeProcessingTransforms != null)
                 {
-                    foreach (var pageTransform in BeforeProcessingTransforms)
+                    foreach (var transform in BeforeProcessingTransforms)
                     {
-                        pageTransform.Transform(context);
+                        transform.Transform(context);
                     }
                 }
 


### PR DESCRIPTION
This PR adds a new extension point `IBeforeProcessingTransform`. Its method `IBeforeProcessingTransform.Transform(SiteContext)` is called after all pages and posts are loaded. This enables plugins to add additional information to a page's bag.

E.g. I've written this plugin to support **series**, which replaces the `series`tag in the frontmatter with a list of all posts with the same `series` tag:
```cs
public class SeriesPageTransform : IBeforeProcessingTransform {
    private const string SeriesTag = "series";

    public void Transform(SiteContext context) {
        var allPages = context.Posts.Concat(context.Pages);

        var allSeries = from page in allPages
            let series = GetSeriesFromPost(page)
            where series != null
            group page by series;

        foreach (var series in allSeries) {
            var allPagesForSeries = series.OrderBy(p => p.Date).ToList();
            foreach (var page in series) {
                page.Bag[SeriesTag] = allPagesForSeries;
            }
        }
    }

    private static string GetSeriesFromPost(Page page) {
        object obj;
        return page.Bag.TryGetValue(SeriesTag, out obj) ? obj as string : null;
    }
}
```

I'm unsure about the name `IBeforeProcessingTransform` but I couldn't think of something better. (You know, the [two hard things in CS](http://martinfowler.com/bliki/TwoHardThings.html) :wink:). If you know a better name I'd appreciate it.

BTW, I had to make `Configuration` public so I can use it in my unit tests.