### PR TITLE
Fix failing build on dev machine configured for NuGet V3

### DIFF
--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -3,4 +3,7 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <packageSources>
+    <add key="NuGet official package source" value="https://www.nuget.org/api/v2" />
+  </packageSources>
 </configuration>


### PR DESCRIPTION
Pretzel build script (.\BuildScripts\build.cmd) uses NuGet 2.8
(.\src\.nuget\NuGet.exe). If the development machine only has Visual
Studio 2015 then its probably configured for NuGet V3 and therefore
the build fails.

This commit adds `<packageSources> ... </packageSources>` to
.\src\.nuget\NuGet.Config to remove build machine dependencies.