### PR TITLE
Set of improvements for pretzel engine

### DIFF
--- a/src/Pretzel.Logic/Commands/BaseParameters.cs
+++ b/src/Pretzel.Logic/Commands/BaseParameters.cs
@@ -21,6 +21,8 @@ namespace Pretzel.Logic.Commands
         [Export("SourcePath")]
         public string Path { get; private set; }
 
+        public string Configuration { get; private set; }
+
         [Export]
         public IFileSystem FileSystem { get; private set; }
 
@@ -30,11 +32,12 @@ namespace Pretzel.Logic.Commands
         {
             Options = new OptionSet
                 {
-                    {"help", "Display help mode", p => Help = true},
-                    {"debug", "Enable debugging", p => Debug = true},
+                    {"help", "Display help mode", p => Help = true },
+                    {"debug", "Enable debugging", p => Debug = true },
                     { "safe", "Disable custom plugins", v => Safe = true },
                     { "d|directory=", "[Obsolete, use --source instead] The path to site directory", p => Path = p },
-                    { "s|source=", "The path to the source site (default current directory)", p => Path = p}
+                    { "s|source=", "The path to the source site (default current directory)", p => Path = p },
+                    { "с|configuration=", "Configuration", c => Configuration = c }
                 };
 
             FileSystem = fileSystem;

--- a/src/Pretzel.Logic/Configuration.cs
+++ b/src/Pretzel.Logic/Configuration.cs
@@ -54,15 +54,27 @@ namespace Pretzel.Logic
             {
                 _config.Add("date", "2012-01-01");
             }
+            if (!_config.ContainsKey("configuration"))
+            {
+                _config.Add("configuration", "debug");
+            }
         }
 
-        internal void ReadFromFile()
+        internal void ReadFromFile(IDictionary<string, string> defaults = null)
         {
             _config = new Dictionary<string, object>();
             if (_fileSystem.File.Exists(_configFilePath))
             {
                 _config = _fileSystem.File.ReadAllText(_configFilePath).ParseYaml();
                 CheckDefaultConfig();
+            }
+
+            if (defaults != null)
+            {
+                foreach (var key in defaults)
+                {
+                    _config[key.Key] = key.Value;
+                }
             }
         }
 

--- a/src/Pretzel.Logic/Liquid/DefaultFilter.cs
+++ b/src/Pretzel.Logic/Liquid/DefaultFilter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pretzel.Logic.Liquid
+{
+    public static class DefaultFilter
+    {
+        public static string Default(string input, string @defaultValue)
+        {
+            return !string.IsNullOrWhiteSpace(input) ? input : defaultValue;
+        }
+    }
+}

--- a/src/Pretzel.Logic/Pretzel.Logic.csproj
+++ b/src/Pretzel.Logic/Pretzel.Logic.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Liquid\DateToRfc822FormatFilter.cs" />
     <Compile Include="Liquid\DateToStringFilter.cs" />
     <Compile Include="Liquid\DateToXmlSchemaFilter.cs" />
+    <Compile Include="Liquid\DefaultFilter.cs" />
     <Compile Include="Liquid\HighlightBlock.cs" />
     <Compile Include="Liquid\NumberOfWordsFilter.cs" />
     <Compile Include="Extensibility\Extensions\PostUrlTag.cs" />

--- a/src/Pretzel.Logic/Templating/Context/Page.cs
+++ b/src/Pretzel.Logic/Templating/Context/Page.cs
@@ -20,6 +20,7 @@ namespace Pretzel.Logic.Templating.Context
         public IEnumerable<string> Categories { get; set; }
         public IEnumerable<string> Tags { get; set; }
         public string Content { get; set; }
+        public string Excerpt { get; set; }
         public string Filepath { get; set; }
         public IDictionary<string, object> Bag { get; set; }
         public IEnumerable<Page> DirectoryPages { get; set; }

--- a/src/Pretzel.Logic/Templating/Context/Paginator.cs
+++ b/src/Pretzel.Logic/Templating/Context/Paginator.cs
@@ -8,7 +8,8 @@ namespace Pretzel.Logic.Templating.Context
     public class Paginator : Drop
     {
         private readonly SiteContext site;
-        
+        private readonly Func<Page, bool> postsFilter;
+
         public int TotalPages { get; set; }
         public int TotalPosts { get; set; }
         public int PerPage { get; set; }
@@ -17,20 +18,23 @@ namespace Pretzel.Logic.Templating.Context
         public string PreviousPageUrl { get; set; }
         public string NextPageUrl { get; set; }
         public int Page { get; set; }
+        public string ListKey { get; set; }
 
         private IList<Page> posts;
         public IList<Page> Posts
         {
-            get { return posts ?? (posts = site.Posts.Skip((Page-1) * PerPage).Take(PerPage).ToList()); }
+            get { return posts ?? (posts = site.Posts.Where(postsFilter ?? (p => true)).Skip((Page-1) * PerPage).Take(PerPage).ToList()); }
         }
 
-        public Paginator(SiteContext site, int totalPages, int perPage, int page)
+        public Paginator(SiteContext site, int totalPages, int perPage, int page, Func<Page, bool> postsFilter = null, string listKey = null)
         {
             this.site = site;
+            this.postsFilter = postsFilter;
             TotalPosts = site.Posts.Count;
             TotalPages = totalPages;
             PerPage = perPage;
             Page = page;
+            ListKey = listKey;
         }
     }
 }

--- a/src/Pretzel.Logic/Templating/Jekyll/LiquidEngine.cs
+++ b/src/Pretzel.Logic/Templating/Jekyll/LiquidEngine.cs
@@ -106,6 +106,7 @@ namespace Pretzel.Logic.Templating.Jekyll
             Template.RegisterFilter(typeof(CgiEscapeFilter));
             Template.RegisterFilter(typeof(UriEscapeFilter));
             Template.RegisterFilter(typeof(NumberOfWordsFilter));
+            Template.RegisterFilter(typeof(DefaultFilter));
             Template.RegisterTag<HighlightBlock>("highlight");
         }
     }

--- a/src/Pretzel/Pretzel.csproj
+++ b/src/Pretzel/Pretzel.csproj
@@ -65,6 +65,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Abstractions">
       <HintPath>..\packages\System.IO.Abstractions.2.0.0.116\lib\net40\System.IO.Abstractions.dll</HintPath>

--- a/src/Pretzel/Program.cs
+++ b/src/Pretzel/Program.cs
@@ -8,11 +8,16 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
+using System.Configuration;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Web.Configuration;
+using Configuration = Pretzel.Logic.Configuration;
 
 namespace Pretzel
 {
@@ -26,6 +31,11 @@ namespace Pretzel
             Tracing.Logger.SetWriter(Console.Out);
             Tracing.Logger.AddCategory(Tracing.Category.Info);
             Tracing.Logger.AddCategory(Tracing.Category.Error);
+
+            if (ConfigurationManager.AppSettings.AllKeys.Contains("culture"))
+                Thread.CurrentThread.CurrentCulture =
+                    Thread.CurrentThread.CurrentUICulture =
+                        new CultureInfo(ConfigurationManager.AppSettings["culture"]);
 
             var parameters = BaseParameters.Parse(args, new FileSystem());
 

--- a/src/Pretzel/Program.cs
+++ b/src/Pretzel/Program.cs
@@ -4,6 +4,7 @@ using Pretzel.Logic;
 using Pretzel.Logic.Commands;
 using Pretzel.Logic.Extensions;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
@@ -97,7 +98,8 @@ namespace Pretzel
                 batch.AddPart(parameters);
 
                 var config = new Configuration(parameters.FileSystem, parameters.Path);
-                config.ReadFromFile();
+                config.ReadFromFile(new Dictionary<string, string> { { "configuration", parameters.Configuration ?? "debug" } });
+
                 batch.AddExportedValue((IConfiguration)config);
 
                 container.Compose(batch);

--- a/src/Pretzel/app.config
+++ b/src/Pretzel/app.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="culture" value="en-US"/>
+  </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>


### PR DESCRIPTION
1. Pagination support added for tags and categories pages
2. `--configuration` parameter added for pretzel.exe (it's possible to access it at site pages, for example)
3. `_data` folder support added (now you can place .`.yml` files there as additional dictionary)
4. `Default` filter added

I just added following sections to wiki:
1. Tags/categories: [wiki](https://github.com/Code52/pretzel/wiki/Tags-and-categories-page)
2. Data files: [wiki](https://github.com/Code52/pretzel/wiki/Data-Files)
3. `--configuration` paramerter: [wiki](https://github.com/Code52/pretzel/wiki/Configuration)
