### PR TITLE
Added support for specifying frontmatter defaults in _config.yml

### DIFF
--- a/src/Pretzel.Logic/DefaultsConfiguration.cs
+++ b/src/Pretzel.Logic/DefaultsConfiguration.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Pretzel.Logic.Extensions;
+
+namespace Pretzel.Logic
+{
+    public interface IDefaultsConfiguration
+    {
+        IDictionary<string, object> ForScope(string path);
+    }
+
+    internal sealed class DefaultsConfiguration : IDefaultsConfiguration
+    {
+        private readonly IDictionary<string, IDictionary<string, object>> _scopedValues;
+
+        public DefaultsConfiguration(IDictionary<string, object> configuration)
+        {
+            _scopedValues = new Dictionary<string, IDictionary<string, object>>();
+            FillScopedValues(configuration);
+        }
+
+        private void FillScopedValues(IDictionary<string, object> configuration)
+        {
+            if (!configuration.ContainsKey("defaults")) return;
+
+            var defaults = configuration["defaults"] as List<object>;
+            if (defaults == null) return;
+
+            foreach (var item in defaults.ConvertAll(x => x as IDictionary<string, object>))
+            {
+                if (item != null && item.ContainsKey("scope") && item.ContainsKey("values"))
+                {
+                    var scopeDictionary = item["scope"] as IDictionary<string, object>;
+                    if (scopeDictionary != null && scopeDictionary.ContainsKey("path"))
+                    {
+                        var path = (string)scopeDictionary["path"];
+                        var values = item["values"] as IDictionary<string, object>;
+                        _scopedValues.Add(path, values ?? new Dictionary<string, object>());
+                    }
+                }
+            }
+        }
+
+        public IDictionary<string, object> ForScope(string path)
+        {
+            IDictionary<string, object> result = new Dictionary<string, object>();
+
+            if (path == null) return result;
+
+            if (path.Length > 0)
+            {
+                result = result.Merge(ForScope(Path.GetDirectoryName(path)));
+            }
+            if (_scopedValues.ContainsKey(path))
+            {
+                result = result.Merge(_scopedValues[path]);
+            }
+            return result;
+        }
+    }
+}

--- a/src/Pretzel.Logic/Extensions/DictionaryExtensions.cs
+++ b/src/Pretzel.Logic/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace Pretzel.Logic.Extensions
+{
+    /// <summary>
+    /// Dictionary extension methods.
+    /// </summary>
+    public static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Merges two dictionaries on top of each other and returns a new dictionary.
+        /// Values from the second override the original values when the key is already present.
+        /// Values from the second will be added when the key is not present in the first.
+        /// </summary>
+        public static IDictionary<TKey, TValue> Merge<TKey, TValue>(this IDictionary<TKey, TValue> first, IDictionary<TKey, TValue> second)
+        {
+            var result = new Dictionary<TKey,TValue>(first);
+            if (second != null)
+            {
+                foreach (var key in second.Keys)
+                {
+                    result[key] = second[key];
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/src/Pretzel.Logic/Pretzel.Logic.csproj
+++ b/src/Pretzel.Logic/Pretzel.Logic.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Commands\CommandParameters.cs" />
     <Compile Include="Commands\BaseParameters.cs" />
     <Compile Include="Configuration.cs" />
+    <Compile Include="DefaultsConfiguration.cs" />
     <Compile Include="Exceptions\PageProcessingException.cs" />
     <Compile Include="Extensibility\Extensions\AzureHostSupport.cs" />
     <Compile Include="Extensibility\Extensions\CommonMarkEngine.cs" />

--- a/src/Pretzel.Logic/Pretzel.Logic.csproj
+++ b/src/Pretzel.Logic/Pretzel.Logic.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Extensibility\IBeforeProcessingTransform.cs" />
     <Compile Include="Extensibility\ITag.cs" />
     <Compile Include="Extensibility\TagFactoryBase.cs" />
+    <Compile Include="Extensions\DictionaryExtensions.cs" />
     <Compile Include="Extensions\IAssembly.cs" />
     <Compile Include="Extensions\Logger.cs" />
     <Compile Include="Extensions\Sitemap.cs" />

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -227,7 +227,11 @@ namespace Pretzel.Logic.Templating.Context
                 if (pageCache.ContainsKey(file))
                     return pageCache[file];
                 var content = SafeReadContents(file);
-                var header = content.YamlHeader();
+
+                var relativePath = MapToOutputPath(context, file);
+                var scopedDefaults = context.Config.GetDefaults().ForScope(relativePath);
+
+                var header = scopedDefaults.Merge(content.YamlHeader());
 
                 if (header.ContainsKey("published") && header["published"].ToString().ToLower() == "false")
                 {

--- a/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
+++ b/src/Pretzel.Logic/Templating/Context/SiteContextGenerator.cs
@@ -229,7 +229,7 @@ namespace Pretzel.Logic.Templating.Context
                 var content = SafeReadContents(file);
 
                 var relativePath = MapToOutputPath(context, file);
-                var scopedDefaults = context.Config.GetDefaults().ForScope(relativePath);
+                var scopedDefaults = context.Config.Defaults.ForScope(relativePath);
 
                 var header = scopedDefaults.Merge(content.YamlHeader());
 

--- a/src/Pretzel.Tests/ConfigurationMock.cs
+++ b/src/Pretzel.Tests/ConfigurationMock.cs
@@ -61,9 +61,9 @@ namespace Pretzel.Tests
             return new Dictionary<string, object>(_config);
         }
 
-        public IDefaultsConfiguration GetDefaults()
+        public IDefaultsConfiguration Defaults
         {
-            return new DefaultsConfigurationMock();
+            get { return new DefaultsConfigurationMock(); }
         }
     }
 

--- a/src/Pretzel.Tests/ConfigurationMock.cs
+++ b/src/Pretzel.Tests/ConfigurationMock.cs
@@ -60,5 +60,19 @@ namespace Pretzel.Tests
         {
             return new Dictionary<string, object>(_config);
         }
+
+        public IDefaultsConfiguration GetDefaults()
+        {
+            return new DefaultsConfigurationMock();
+        }
     }
+
+    internal class DefaultsConfigurationMock : IDefaultsConfiguration
+    {
+        public IDictionary<string, object> ForScope(string path)
+        {
+            return new Dictionary<string, object>();
+        }
+    }
+
 }

--- a/src/Pretzel.Tests/ConfigurationTests.cs
+++ b/src/Pretzel.Tests/ConfigurationTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO.Abstractions.TestingHelpers;
+using Pretzel.Logic;
+using Pretzel.Logic.Extensions;
+using Xunit;
+
+namespace Pretzel.Tests
+{
+    public class ConfigurationTests
+    {
+        private Configuration _sut;
+        private const string SampleConfig = @"
+pretzel:
+  engine: liquid
+
+title: 'Site Title'
+
+defaults:
+  -
+    scope:
+      path: ''
+    values:
+      author: 'default-author'
+  -
+    scope:
+      path: '_posts'
+    values:
+      layout: 'post'
+      author: 'posts-specific-author'
+  -
+    scope:
+      path: '_posts\2016'
+    values:
+      layout: 'post-layout-for-2016'
+";
+
+        public ConfigurationTests()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(@"C:\WebSite\_config.yml", new MockFileData(SampleConfig));
+
+            _sut = new Configuration(fileSystem, @"C:\WebSite");
+            _sut.ReadFromFile();
+        }
+
+        [Fact]
+        public void Indexer_should_correctly_return_the_value()
+        {
+            Assert.Equal("Site Title", _sut["title"]);
+        }
+
+        [Fact]
+        public void Permalinks_should_be_added_with_default_value_if_not_specified_in_file()
+        {
+            Assert.Equal(Configuration.DefaultPermalink, _sut["permalink"]);
+        }
+
+        [Fact]
+        public void DefaultsForScope_should_layer_the_most_specific_scope_on_top()
+        {
+            var defaults = _sut.GetDefaults().ForScope(@"_posts\2016");
+
+            Assert.Equal("post-layout-for-2016", defaults["layout"]);
+        }
+
+        [Fact]
+        public void DefaultsForScope_should_take_value_from_less_specific_when_not_found_in_most_specific()
+        {
+            var defaults = _sut.GetDefaults().ForScope(@"_posts\2016");
+
+            Assert.Equal("posts-specific-author", defaults["author"]);
+        }
+
+        [Fact]
+        public void DefaultsForScope_should_fallback_to_value_from_empty_path_when_given_path_not_found()
+        {
+            var defaults = _sut.GetDefaults().ForScope("_nonexisting");
+
+            Assert.Equal("default-author", defaults["author"]);
+        }
+    }
+}

--- a/src/Pretzel.Tests/ConfigurationTests.cs
+++ b/src/Pretzel.Tests/ConfigurationTests.cs
@@ -8,7 +8,8 @@ namespace Pretzel.Tests
 {
     public class ConfigurationTests
     {
-        private Configuration _sut;
+        private readonly Configuration _sut;
+
         private const string SampleConfig = @"
 pretzel:
   engine: liquid
@@ -58,7 +59,7 @@ defaults:
         [Fact]
         public void DefaultsForScope_should_layer_the_most_specific_scope_on_top()
         {
-            var defaults = _sut.GetDefaults().ForScope(@"_posts\2016");
+            var defaults = _sut.Defaults.ForScope(@"_posts\2016");
 
             Assert.Equal("post-layout-for-2016", defaults["layout"]);
         }
@@ -66,7 +67,7 @@ defaults:
         [Fact]
         public void DefaultsForScope_should_take_value_from_less_specific_when_not_found_in_most_specific()
         {
-            var defaults = _sut.GetDefaults().ForScope(@"_posts\2016");
+            var defaults = _sut.Defaults.ForScope(@"_posts\2016");
 
             Assert.Equal("posts-specific-author", defaults["author"]);
         }
@@ -74,7 +75,7 @@ defaults:
         [Fact]
         public void DefaultsForScope_should_fallback_to_value_from_empty_path_when_given_path_not_found()
         {
-            var defaults = _sut.GetDefaults().ForScope("_nonexisting");
+            var defaults = _sut.Defaults.ForScope("_nonexisting");
 
             Assert.Equal("default-author", defaults["author"]);
         }

--- a/src/Pretzel.Tests/Extensions/DictionaryExtensionTests.cs
+++ b/src/Pretzel.Tests/Extensions/DictionaryExtensionTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using Pretzel.Logic.Extensions;
+using Xunit;
+
+namespace Pretzel.Tests.Extensions
+{
+    public class DictionaryExtensionTests
+    {
+        [Fact]
+        public void Merge_two_dictionaries_returns_new_merged_dictionary()
+        {
+            var first = new Dictionary<string, string>
+            {
+                { "A", "a-first" },
+                { "B", "b-first" },
+            };
+            var second = new Dictionary<string, string>
+            {
+                { "A", "a-second" },
+                { "C", "c-second" },
+            };
+
+            var merged = first.Merge(second);
+
+            Assert.Equal(3, merged.Count);
+            Assert.Equal("a-second", merged["A"]);
+            Assert.Equal("b-first", merged["B"]);
+            Assert.Equal("c-second", merged["C"]);
+        }
+
+        [Fact]
+        public void Merge_with_null_returns_copy_of_first()
+        {
+            var first = new Dictionary<string, string>
+            {
+                { "A", "a-first" },
+                { "B", "b-first" },
+            };
+
+            var merged = first.Merge(null);
+
+            Assert.NotSame(merged, first);
+            Assert.Equal(2, merged.Count);
+            Assert.Equal("a-first", merged["A"]);
+            Assert.Equal("b-first", merged["B"]);
+        }
+    }
+}

--- a/src/Pretzel.Tests/Pretzel.Tests.csproj
+++ b/src/Pretzel.Tests/Pretzel.Tests.csproj
@@ -91,9 +91,11 @@
     <Compile Include="Commands\BaseParameterTests.cs" />
     <Compile Include="Commands\CommandExtensions.cs" />
     <Compile Include="ConfigurationMock.cs" />
+    <Compile Include="ConfigurationTests.cs" />
     <Compile Include="Extensibility\Extensions\AzureHostSupportTest.cs" />
     <Compile Include="Extensibility\Extensions\VirtualDirectorySupportTests.cs" />
     <Compile Include="Extensibility\Extensions\WebSequenceDiagramsTests.cs" />
+    <Compile Include="Extensions\DictionaryExtensionTests.cs" />
     <Compile Include="Extensions\SitemapTest.cs" />
     <Compile Include="Extensions\StringExtensionsTest.cs" />
     <Compile Include="Import\BloggerImportTests.cs" />


### PR DESCRIPTION
Functionality is based on:
https://jekyllrb.com/docs/configuration/#front-matter-defaults

Resolves #305

Note: I removed adding a fixed date of '2012-01-01' to the dictionary if
not specified in the _config.yml. It was never used.