### PR TITLE
Fix the files are rendered too much time

### DIFF
--- a/src/Pretzel.Logic/Templating/JekyllEngineBase.cs
+++ b/src/Pretzel.Logic/Templating/JekyllEngineBase.cs
@@ -39,7 +39,7 @@ namespace Pretzel.Logic.Templating
 
         [Import(AllowDefault = true)]
         private ILightweightMarkupEngine _lightweightMarkupEngine;
-        
+
         public abstract void Initialize();
 
         protected abstract void PreProcess();
@@ -211,22 +211,6 @@ namespace Pretzel.Logic.Templating
                     continue;
                 }
 
-                try
-                {
-                    context.FullContent = RenderTemplate(context.FullContent, context);
-                }
-                catch (Exception ex)
-                {
-                    if (!skipFileOnError)
-                    {
-                        var message = string.Format("Failed to process {0}, see inner exception for more details", context.OutputPath);
-                        throw new PageProcessingException(message, ex);
-                    }
-
-                    Console.WriteLine(@"Failed to process {0}: {1}", context.OutputPath, ex);
-                    continue;
-                }
-
                 CreateOutputDirectory(context.OutputPath);
                 FileSystem.File.WriteAllText(context.OutputPath, context.FullContent);
             }
@@ -242,7 +226,7 @@ namespace Pretzel.Logic.Templating
                 html = Path.GetExtension(file).IsMarkdownFile()
                        ? _lightweightMarkupEngine.Convert(contentsWithoutHeader).Trim()
                        : contentsWithoutHeader;
-                
+
                 if (ContentTransformers != null)
                 {
                     html = ContentTransformers.Aggregate(html, (current, contentTransformer) => contentTransformer.Transform(current));


### PR DESCRIPTION
In general case this cause no problem, unless if you have some liquid's specific syntax included in a `{% raw %}` tag: the last time the file are rendered since the content already have been processed the `{% raw %}` tag is gone and the content bare, resulting in an exception.