### PR TITLE
Removed link to Jabbr chatroom - broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Once you're familiar with Git and GitHub, clone the repository and run the ```.\
 ### Discussing ideas 
 
 * [Trello Board](https://trello.com/board/pretzel/4f25ffb3dbbed1ab5a4f0f5a) - add ideas, or claim an idea and start working on it!
-* [JabbR Chatroom](http://jabbr.net/#/rooms/code52) - discuss things in real-time with people all over the world!
 
 ### Links
 - [ColorCode Fork](https://github.com/csainty/ColorCode) - Switch from inline html to stylesheet approach 


### PR DESCRIPTION
Most of the JabbR websites seem to be down, although this one is still up: http://about.jabbr.net/ 
Last code comitted to project was 2016. Is project dead?