### PR TITLE
Fix local and AppVeyor builds

### DIFF
--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -126,7 +126,7 @@ function ExecuteTests($cover)
     If($cover -eq $true)
     {
         cinst opencover.portable -y
-        cinst coveralls.io -source https://nuget.org/api/v2/
+        cinst coveralls.io -source https://api.nuget.org/v3/index.json
         & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:user -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode
         & coveralls.net --opencover $artifacts\coverage.xml
     }
@@ -150,7 +150,7 @@ function Build()
         If ($env:APPVEYOR_SCHEDULED_BUILD -eq $true)
         {
             # Coverity
-            cinst PublishCoverity -source https://nuget.org/api/v2/
+            cinst PublishCoverity -source https://api.nuget.org/v3/index.json
             
             cov-configure --config cov-config.xml --cs
             

--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -85,9 +85,9 @@ function CreatePackage($versionInfos)
 
     # create Pretzel zip
     RemoveIfExists Pretzel.$version.zip
-    7z a $artifacts\Pretzel.$version.zip $src\Pretzel\bin\Release\*.dll
-    7z a $artifacts\Pretzel.$version.zip $src\Pretzel\bin\Release\Pretzel.exe
-    7z a $artifacts\Pretzel.$version.zip $src\Pretzel\bin\Release\Pretzel.exe.config
+    7z a $artifacts\Pretzel.$version.zip $src\Pretzel\bin\Release\net451\*.dll
+    7z a $artifacts\Pretzel.$version.zip $src\Pretzel\bin\Release\net451\Pretzel.exe
+    7z a $artifacts\Pretzel.$version.zip $src\Pretzel\bin\Release\net451\Pretzel.exe.config
     7z a $artifacts\Pretzel.$version.zip ReleaseNotes.md
 
     # build Pretzel nupkg
@@ -102,7 +102,7 @@ function CreatePackage($versionInfos)
 
     # create Pretzel.ScriptCs zip
     RemoveIfExists Pretzel.ScriptCs.$version.zip
-    7z a $artifacts\Pretzel.ScriptCs.$version.zip $src\Pretzel.ScriptCs\bin\Release\*.dll
+    7z a $artifacts\Pretzel.ScriptCs.$version.zip $src\Pretzel.ScriptCs\bin\Release\net451\*.dll
 
     # build Pretzel.ScriptCs nupkg
     

--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -126,7 +126,7 @@ function ExecuteTests($cover)
     If($cover -eq $true)
     {
         cinst opencover.portable -y
-        cinst coveralls.io -source https://api.nuget.org/v3/index.json
+        cinst coveralls.io -source https://nuget.org/api/v2/
         & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:user -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode
         & coveralls.net --opencover $artifacts\coverage.xml
     }
@@ -150,7 +150,7 @@ function Build()
         If ($env:APPVEYOR_SCHEDULED_BUILD -eq $true)
         {
             # Coverity
-            cinst PublishCoverity -source https://api.nuget.org/v3/index.json
+            cinst PublishCoverity -source https://nuget.org/api/v2/
             
             cov-configure --config cov-config.xml --cs
             

--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -170,7 +170,7 @@ function Build()
         }
         Else
         {
-            & msbuild "$src\Pretzel.sln" /p:Configuration="Release";AssemblyFileVersion=$env:GitVersion_AssemblySemFileVer;AssemblyVersion=$env:GitVersion_AssemblySemVer /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+            & msbuild "$src\Pretzel.sln" /p:Configuration="Release" /p:AssemblyFileVersion=$env:GitVersion_AssemblySemFileVer /p:AssemblyVersion=$env:GitVersion_AssemblySemVer /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
             if ($LastExitCode -ne 0) { throw "Building solution failed" }
 

--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -127,12 +127,12 @@ function ExecuteTests($cover)
     {
         cinst opencover.portable -y
         cinst coveralls.io -source https://nuget.org/api/v2/
-        & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:user -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode
+        & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:user -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode
         & coveralls.net --opencover $artifacts\coverage.xml
     }
     Else
     {
-        &$tools\xunit\xunit.console.exe "$src\Pretzel.Tests\bin\Release\Pretzel.Tests.dll"
+        &$tools\xunit\xunit.console.exe "$src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"
     }
     
     if ($LastExitCode -ne 0) { throw "Tests failed" }
@@ -184,13 +184,9 @@ function Build()
     #Local build
     Else
     {
-        Write-Warning "Chocolatey must be installed, along with Nuget.CommandLine, SevenZip and MSBuild Tools 2015."
+        Write-Warning "Chocolatey must be installed, along with Nuget.CommandLine, SevenZip, Visual Studio 2017 or later and VSWhere."
         
-        $msBuildVersion = "14.0"
-        $regKey = "HKLM:\software\Microsoft\MSBuild\ToolsVersions\$msBuildVersion"
-        $regProperty = "MSBuildToolsPath"
-        
-        $msbuildExe = join-path -path (Get-ItemProperty $regKey).$regProperty -childpath "msbuild.exe"
+        $msbuildExe = &vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
         
         &$msbuildExe "$src\Pretzel.sln" /p:Configuration="Release" /verbosity:minimal
 

--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -170,7 +170,7 @@ function Build()
         }
         Else
         {
-            & msbuild "$src\Pretzel.sln" /p:Configuration="Release" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+            & msbuild "$src\Pretzel.sln" /p:Configuration="Release";AssemblyFileVersion=$env:GitVersion_AssemblySemFileVer;AssemblyVersion=$env:GitVersion_AssemblySemVer /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
             if ($LastExitCode -ne 0) { throw "Building solution failed" }
 

--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -127,7 +127,7 @@ function ExecuteTests($cover)
     {
         cinst opencover.portable -y
         cinst coveralls.io -source https://nuget.org/api/v2/
-        & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:user -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode
+        & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:user -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode -log:All
         & coveralls.net --opencover $artifacts\coverage.xml
     }
     Else

--- a/BuildScripts/AppVeyor-Build.ps1
+++ b/BuildScripts/AppVeyor-Build.ps1
@@ -127,7 +127,7 @@ function ExecuteTests($cover)
     {
         cinst opencover.portable -y
         cinst coveralls.io -source https://nuget.org/api/v2/
-        & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:user -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode -log:All
+        & C:\ProgramData\chocolatey\lib\opencover.portable\tools\OpenCover.Console.exe -register:administrator -filter:"+[Pretzel.Logic]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -target:"%xunit20%\xunit.console.exe" -targetargs:"""src\Pretzel.Tests\bin\Release\net462\Pretzel.Tests.dll"" -noshadow -appveyor" -output:$artifacts\coverage.xml -returntargetcode -log:All
         & coveralls.net --opencover $artifacts\coverage.xml
     }
     Else

--- a/BuildScripts/build.cmd
+++ b/BuildScripts/build.cmd
@@ -4,6 +4,12 @@ if "%config%" == "" (
    set config=Release
 )
 
-"%ProgramFiles(x86)%\MSBuild\14.0\Bin\msbuild" %~dp0/build.proj /p:Configuration="%config%" /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+
+
+FOR /F "tokens=* USEBACKQ" %%F IN (`vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
+    SET msbuild=%%F
+)
+
+"%msbuild%" %~dp0/build.proj /p:Configuration="%config%" /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 
 pause

--- a/BuildScripts/build.proj
+++ b/BuildScripts/build.proj
@@ -40,7 +40,7 @@
     <MSBuild Projects="$(SourceDir)\Pretzel.sln" Properties="Configuration=$(Configuration)" Targets="Rebuild" />
     <MakeDir Directories="$(ArtifactsDir)" />
     <RemoveDir Directories="$(TestsDir)" />
-    <Copy SourceFiles="$(SourceDir)\Pretzel\bin\$(Configuration)\Pretzel.exe"
+    <Copy SourceFiles="$(SourceDir)\Pretzel\bin\$(Configuration)\net451\Pretzel.exe"
           DestinationFolder="$(ArtifactsDir)" />
     <Copy SourceFiles="@(TestsDll)"
           DestinationFolder="$(TestsDir)" />
@@ -53,7 +53,7 @@
   <Target Name="Test">
     <Message Text="=========== Run Tests ===========" Importance="High" />
     <ItemGroup>
-      <TestFiles Include="$(MSBuildProjectDirectory)\..\**\bin\$(Configuration)\*Tests.dll" />
+      <TestFiles Include="$(MSBuildProjectDirectory)\..\**\bin\$(Configuration)\**\Tests.dll" />
     </ItemGroup>
     <xunit Assemblies="@(TestFiles)" />
     <Message Text="=========== Tests Passed ===========" Importance="High" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 configuration: Release
 
 install:
-  - choco install gitversion.portable - choco install gitversion.portable
+  - choco install gitversion.portable --version 4.0.0
   - GitVersion /output buildserver /UpdateAssemblyInfo true
 
 #cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,9 @@ install:
   - choco install gitversion.portable --version 4.0.0
   - GitVersion /output buildserver
 
-#cache:
-#  - src\packages -> src/**/packages.config
-#  - C:\ProgramData\chocolatey\bin\OpenCover.Console.exe -> appveyor.yml
-#  - C:\ProgramData\chocolatey\bin\coveralls.net.exe -> appveyor.yml
-#  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 environment:
   COVERALLS_REPO_TOKEN:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ configuration: Release
 
 install:
   - choco install gitversion.portable --version 4.0.0
-  - GitVersion /output buildserver /UpdateAssemblyInfo true
+  - GitVersion /output buildserver
 
 #cache:
 #  - src\packages -> src/**/packages.config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@
 configuration: Release
 
 install:
+  - choco install gitversion.portable - choco install gitversion.portable
   - GitVersion /output buildserver /UpdateAssemblyInfo true
 
 #cache:

--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -4,6 +4,6 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
-    <add key="NuGet official package source" value="https://www.nuget.org/api/v2" />
+    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Things to check:
- [x] assembly and assembly file version (gitversion have been deactivated because not compatible with the new csproj format)
- [x] OpenCover (not working for now)
- [x] Artifacts for each target (net462 only for now)